### PR TITLE
remove protection meta after use

### DIFF
--- a/source/GStreamerEMEUtils.cpp
+++ b/source/GStreamerEMEUtils.cpp
@@ -190,5 +190,6 @@ void ProcessProtectionMetadata(GstBuffer *buffer, BufferProtectionMetadata &meta
             getSubSamplesFromProtectionMetadata(protectionMeta, metadata);
             getInitWithLast15FromProtectionMetadata(protectionMeta, metadata);
         }
+        gst_buffer_remove_meta(buffer, reinterpret_cast<GstMeta *>(protectionMeta));
     }
 }


### PR DESCRIPTION
Summary: Remove protection meta after use.
Type: Feature
Owner: Marcin Wojciechowski
Reviewers: Adam Czynszak, Stuart Pett
Coding Standard Applied: Y
Test Plan: None
Dependencies and Impacts: None
Jira: None