### PR TITLE
RDKCMF-8878 rialto-gstreamer build failure in RPi4 Hybrid 64bit

### DIFF
--- a/source/BufferParser.cpp
+++ b/source/BufferParser.cpp
@@ -76,10 +76,9 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
 
     if (metadata.encrypted)
     {
-        GST_DEBUG("encrypted: %d mksId: %d key len: %lu iv len: %lu SUBSAMPLES: %lu, initWithLast15: %u",
-                  metadata.encrypted, metadata.mediaKeySessionId, (long unsigned int) metadata.kid.size(),
-                  (long unsigned int) metadata.iv.size(), (long unsigned int) metadata.subsamples.size(),
-                  metadata.initWithLast15);
+        GST_DEBUG("encrypted: %d mksId: %d key len: %zu iv len: %zu SUBSAMPLES: %zu, initWithLast15: %u",
+                  metadata.encrypted, metadata.mediaKeySessionId, metadata.kid.size(), metadata.iv.size(),
+                  metadata.subsamples.size(), metadata.initWithLast15);
 
         segment->setEncrypted(true);
         segment->setMediaKeySessionId(metadata.mediaKeySessionId);
@@ -90,7 +89,7 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
         size_t subSampleCount = metadata.subsamples.size();
         for (size_t subSampleIdx = 0; subSampleIdx < subSampleCount; ++subSampleIdx)
         {
-            GST_DEBUG("SUBSAMPLE: %lu/%lu C: %d E: %d", (long unsigned int) subSampleIdx, (long unsigned int) subSampleCount,
+            GST_DEBUG("SUBSAMPLE: %zu/%zu C: %d E: %d", subSampleIdx, subSampleCount,
                       metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
             segment->addSubSample(metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
         }

--- a/source/BufferParser.cpp
+++ b/source/BufferParser.cpp
@@ -77,8 +77,9 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
     if (metadata.encrypted)
     {
         GST_DEBUG("encrypted: %d mksId: %d key len: %lu iv len: %lu SUBSAMPLES: %lu, initWithLast15: %u",
-                  metadata.encrypted, metadata.mediaKeySessionId, metadata.kid.size(), metadata.iv.size(),
-                  metadata.subsamples.size(), metadata.initWithLast15);
+                  metadata.encrypted, metadata.mediaKeySessionId, (long unsigned int) metadata.kid.size(),
+                  (long unsigned int) metadata.iv.size(), (long unsigned int) metadata.subsamples.size(),
+                  metadata.initWithLast15);
 
         segment->setEncrypted(true);
         segment->setMediaKeySessionId(metadata.mediaKeySessionId);
@@ -89,7 +90,7 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
         size_t subSampleCount = metadata.subsamples.size();
         for (size_t subSampleIdx = 0; subSampleIdx < subSampleCount; ++subSampleIdx)
         {
-            GST_DEBUG("SUBSAMPLE: %lu/%lu C: %d E: %d", subSampleIdx, subSampleCount,
+            GST_DEBUG("SUBSAMPLE: %lu/%lu C: %d E: %d", (long unsigned int) subSampleIdx, (long unsigned int) subSampleCount,
                       metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
             segment->addSubSample(metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
         }

--- a/source/BufferParser.cpp
+++ b/source/BufferParser.cpp
@@ -76,7 +76,7 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
 
     if (metadata.encrypted)
     {
-        GST_DEBUG("encrypted: %d mksId: %d key len: %d iv len: %d SUBSAMPLES: %d, initWithLast15: %u",
+        GST_DEBUG("encrypted: %d mksId: %d key len: %lu iv len: %lu SUBSAMPLES: %lu, initWithLast15: %u",
                   metadata.encrypted, metadata.mediaKeySessionId, metadata.kid.size(), metadata.iv.size(),
                   metadata.subsamples.size(), metadata.initWithLast15);
 
@@ -89,7 +89,7 @@ void BufferParser::addProtectionMetadataToSegment(std::unique_ptr<IMediaPipeline
         size_t subSampleCount = metadata.subsamples.size();
         for (size_t subSampleIdx = 0; subSampleIdx < subSampleCount; ++subSampleIdx)
         {
-            GST_DEBUG("SUBSAMPLE: %d/%d C: %d E: %d", subSampleIdx, subSampleCount,
+            GST_DEBUG("SUBSAMPLE: %lu/%lu C: %d E: %d", subSampleIdx, subSampleCount,
                       metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
             segment->addSubSample(metadata.subsamples[subSampleIdx].first, metadata.subsamples[subSampleIdx].second);
         }


### PR DESCRIPTION
Build errors in rialto-gstreamer while building RPi4 Hybrid 64bit: Mulitples of:
| rialto-gstreamer/source/BufferParser.cpp:79:19: error: format '%d' expects argument of type 'int', but argument 10 has type 'std::vector<unsigned char>::size_type' \{aka 'long unsigned int'} [-Werror=format=]
|    79 |         GST_DEBUG(encrypted: %d mksId: %d key len: %d iv len: %d SUBSAMPLES: %d, initWithLast15: %u,
|       |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|    80 |                   metadata.encrypted, metadata.mediaKeySessionId, metadata.kid.size(), metadata.iv.size(),
|       |                                                                   ~~~~~~~~~~~~~~~~~~~
|       |                                                                                    |
|       |                                                                                    std::vector<unsigned char>::size_type \{aka long unsigned int}

| rialto-gstreamer/source/BufferParser.cpp:92:23: error: format '%d' expects argument of type 'int', but argument 8 has type 'size_t' \{aka 'long unsigned int'} [-Werror=format=]
|    92 |             GST_DEBUG(SUBSAMPLE: %d/%d C: %d E: %d, subSampleIdx, subSampleCount,
|       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~
|       |                                                       |
|       |                                                       size_t \{aka long unsigned int}