### PR TITLE
Post error on eos in invalid states

### DIFF
--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -65,14 +65,13 @@ static void rialto_mse_base_async_done(RialtoMSEBaseSink *sink)
 
 static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
 {
-    if ((GST_STATE(sink) != GST_STATE_PAUSED) &&
-        (GST_STATE(sink) != GST_STATE_PLAYING))
+    if ((GST_STATE(sink) != GST_STATE_PAUSED) && (GST_STATE(sink) != GST_STATE_PLAYING))
     {
         // Sink cannot post a EOS message in this state, post an error instead.
-        const char* errMessage = "Rialto sinks received EOS in non-playing state";
+        const char *errMessage = "Rialto sinks received EOS in non-playing state";
         gst_element_post_message(GST_ELEMENT_CAST(sink),
-                                 gst_message_new_error(GST_OBJECT_CAST(sink), g_error_new(GST_STREAM_ERROR, 0, errMessage),
-                                                       errMessage));
+                                 gst_message_new_error(GST_OBJECT_CAST(sink),
+                                                       g_error_new(GST_STREAM_ERROR, 0, errMessage), errMessage));
     }
     else
     {

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -67,9 +67,11 @@ static void rialto_mse_base_async_done(RialtoMSEBaseSink *sink)
 
 static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
 {
-    if ((GST_STATE(sink) != GST_STATE_PAUSED) && (GST_STATE(sink) != GST_STATE_PLAYING))
+    GstState currentState = GST_STATE(sink);
+    if ((currentState != GST_STATE_PAUSED) && (currentState != GST_STATE_PLAYING))
     {
-        // Sink cannot post a EOS message in this state, post an error instead.
+        GST_INFO_ERROR(sink, "Sink cannot post a EOS message in state '%s', posting an error instead", gst_element_state_get_name(currentState));
+
         const char *errMessage = "Rialto sinks received EOS in non-playing state";
         gst_element_post_message(GST_ELEMENT_CAST(sink),
                                  gst_message_new_error(GST_OBJECT_CAST(sink),

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -71,7 +71,7 @@ static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
         (GST_STATE_RETURN(sink) == GST_STATE_CHANGE_ASYNC))
     {
         // Force async change to Pause state, otherwise the EOS will be ignored
-        rialto_mse_base_async_done(sink);
+        rialto_mse_base_handle_rialto_server_state_changed(sink, firebolt::rialto::PlaybackState::PAUSED);
     }
     gst_element_post_message(GST_ELEMENT_CAST(sink), gst_message_new_eos(GST_OBJECT_CAST(sink)));
 }

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -70,7 +70,7 @@ static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
     GstState currentState = GST_STATE(sink);
     if ((currentState != GST_STATE_PAUSED) && (currentState != GST_STATE_PLAYING))
     {
-        GST_INFO_ERROR(sink, "Sink cannot post a EOS message in state '%s', posting an error instead", gst_element_state_get_name(currentState));
+        GST_ERROR_OBJECT(sink, "Sink cannot post a EOS message in state '%s', posting an error instead", gst_element_state_get_name(currentState));
 
         const char *errMessage = "Rialto sinks received EOS in non-playing state";
         gst_element_post_message(GST_ELEMENT_CAST(sink),

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -65,6 +65,14 @@ static void rialto_mse_base_async_done(RialtoMSEBaseSink *sink)
 
 static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
 {
+    if ((sink->priv->mIsStateCommitNeeded) &&
+        (GST_STATE(sink) == GST_STATE_READY) &&
+        (GST_STATE_PENDING(sink) == GST_STATE_PAUSED) &&
+        (GST_STATE_RETURN(sink) == GST_STATE_CHANGE_ASYNC))
+    {
+        // Force async change to Pause state, otherwise the EOS will be ignored
+        rialto_mse_base_async_done(sink);
+    }
     gst_element_post_message(GST_ELEMENT_CAST(sink), gst_message_new_eos(GST_OBJECT_CAST(sink)));
 }
 

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -65,10 +65,8 @@ static void rialto_mse_base_async_done(RialtoMSEBaseSink *sink)
 
 static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
 {
-    if ((sink->priv->mIsStateCommitNeeded) &&
-        (GST_STATE(sink) == GST_STATE_READY) &&
-        (GST_STATE_PENDING(sink) == GST_STATE_PAUSED) &&
-        (GST_STATE_RETURN(sink) == GST_STATE_CHANGE_ASYNC))
+    if ((sink->priv->mIsStateCommitNeeded) && (GST_STATE(sink) == GST_STATE_READY) &&
+        (GST_STATE_PENDING(sink) == GST_STATE_PAUSED) && (GST_STATE_RETURN(sink) == GST_STATE_CHANGE_ASYNC))
     {
         // Force async change to Pause state, otherwise the EOS will be ignored
         rialto_mse_base_handle_rialto_server_state_changed(sink, firebolt::rialto::PlaybackState::PAUSED);

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -70,7 +70,8 @@ static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
     GstState currentState = GST_STATE(sink);
     if ((currentState != GST_STATE_PAUSED) && (currentState != GST_STATE_PLAYING))
     {
-        GST_ERROR_OBJECT(sink, "Sink cannot post a EOS message in state '%s', posting an error instead", gst_element_state_get_name(currentState));
+        GST_ERROR_OBJECT(sink, "Sink cannot post a EOS message in state '%s', posting an error instead",
+                         gst_element_state_get_name(currentState));
 
         const char *errMessage = "Rialto sinks received EOS in non-playing state";
         gst_element_post_message(GST_ELEMENT_CAST(sink),


### PR DESCRIPTION
Summary: Post error on the pipeline if EOS is received in a non-playing state, otherwise the message is ignored.
Type: Feature
Test Plan: NPLB
Jira: RIALTO-124