### PR TITLE
Fix build error [-Werror=format-security]

### DIFF
--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -397,9 +397,10 @@ void GStreamerWebAudioPlayerClient::notifyState(firebolt::rialto::WebAudioPlayer
     {
         std::string errMessage = "Rialto server webaudio playback failed";
         GST_ERROR("%s", errMessage.c_str());
-        gst_element_post_message(mAppSink, gst_message_new_error(GST_OBJECT_CAST(mAppSink),
-                                                                 g_error_new(GST_STREAM_ERROR, 0, errMessage.c_str()),
-                                                                 errMessage.c_str()));
+        gst_element_post_message(mAppSink,
+                                 gst_message_new_error(GST_OBJECT_CAST(mAppSink),
+                                                       g_error_new_literal(GST_STREAM_ERROR, 0, errMessage.c_str()),
+                                                       errMessage.c_str()));
         gst_element_set_state(GST_ELEMENT_CAST(mAppSink), GST_STATE_READY);
         break;
     }

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -87,8 +87,8 @@ static void rialto_mse_base_sink_eos_handler(RialtoMSEBaseSink *sink)
 static void rialto_mse_base_sink_error_handler(RialtoMSEBaseSink *sink, const char *message)
 {
     gst_element_post_message(GST_ELEMENT_CAST(sink),
-                             gst_message_new_error(GST_OBJECT_CAST(sink), g_error_new(GST_STREAM_ERROR, 0, message),
-                                                   message));
+                             gst_message_new_error(GST_OBJECT_CAST(sink),
+                                                   g_error_new_literal(GST_STREAM_ERROR, 0, message), message));
     gst_element_set_state(GST_ELEMENT_CAST(sink), GST_STATE_READY);
 }
 


### PR DESCRIPTION
Fix build error like:
source/RialtoGStreamerMSEBaseSink.cpp:74:115: error: format not a string literal and no format arguments [-Werror=format-security]
|    74 |                              gst_message_new_error(GST_OBJECT_CAST(sink), g_error_new(GST_STREAM_ERROR, 0, message),