### PR TITLE
Disable deprecated-declarations for gstreamer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ project( gstrialtosinks LANGUAGES C CXX VERSION 1.0 )
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 add_compile_options(-Wall -Werror)
 
+# RIALTO-197: deprecated-declarations error in the latest stable2 for gstreamer.
+# Should be removed once the issue is fixed.
 add_compile_options(
   "-Wno-deprecated-declarations"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ project( gstrialtosinks LANGUAGES C CXX VERSION 1.0 )
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 add_compile_options(-Wall -Werror)
 
+add_compile_options(
+  "-Wno-deprecated-declarations"
+)
+
 find_package(Rialto 1.0 REQUIRED)
 find_package(ocdmRialto 1.0 REQUIRED)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Summary: Disable deprecated-declarations when compiling rialto-gstreamer to avoid compilation errors.
Type: BugFix
Test Plan: rialto-gstreamer build
Jira: RIALTO-197