### PR TITLE
Remove basesink for webaudio

### DIFF
--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -354,7 +354,7 @@ void GStreamerWebAudioPlayerClient::pushSamples()
     }
 }
 
-void GStreamerWebAudioPlayerClient::getNextBufferData(GstBuffer *buf)
+bool GStreamerWebAudioPlayerClient::getNextBufferData(GstBuffer *buf)
 {
     if (!buf)
     {

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -355,7 +355,7 @@ void GStreamerWebAudioPlayerClient::getNextBufferData(GstBuffer *buf)
     }
 
     mSampleDataBuffer.insert(mSampleDataBuffer.end(), bufferMap.data, bufferMap.data + bufferSize);
-    gst_buffer_unmap(buffer, &bufferMap);
+    gst_buffer_unmap(buf, &bufferMap);
     gst_buffer_unref(buf);
 }
 

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -84,7 +84,8 @@ bool operator!=(const firebolt::rialto::WebAudioPcmConfig &lac, const firebolt::
 } // namespace
 
 GStreamerWebAudioPlayerClient::GStreamerWebAudioPlayerClient(WebAudioSinkCallbacks callbacks)
-    : mIsOpen(false), m_pushSamplesTimer(notifyPushSamplesCallback, this, "notifyPushSamplesCallback"), m_isEos(false), m_config({}), m_callbacks(callbacks)
+    : mIsOpen(false), m_pushSamplesTimer(notifyPushSamplesCallback, this, "notifyPushSamplesCallback"), m_isEos(false),
+      m_config({}), m_callbacks(callbacks)
 {
     mBackendQueue.start();
     mClientBackend = std::make_unique<firebolt::rialto::client::WebAudioClientBackend>();
@@ -265,11 +266,7 @@ bool GStreamerWebAudioPlayerClient::isOpen()
     GST_DEBUG("entry:");
 
     bool result = false;
-    mBackendQueue.callInEventLoop(
-        [&]()
-        {
-            result = mIsOpen;
-        });
+    mBackendQueue.callInEventLoop([&]() { result = mIsOpen; });
 
     return result;
 }

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -83,7 +83,7 @@ bool operator!=(const firebolt::rialto::WebAudioPcmConfig &lac, const firebolt::
 }
 } // namespace
 
-GStreamerWebAudioPlayerClient::GStreamerWebAudioPlayerClient(RialtoWebAudioSink *sink)
+GStreamerWebAudioPlayerClient::GStreamerWebAudioPlayerClient(GstElement *sink)
     : mIsOpen(false), m_pushSamplesTimer(notifyPushSamplesCallback, this, "notifyPushSamplesCallback"), m_isEos(false), m_config({}), mSink(sink)
 {
     mBackendQueue.start();
@@ -413,8 +413,18 @@ void GStreamerWebAudioPlayerClient::notifyState(firebolt::rialto::WebAudioPlayer
         rialto_web_audio_handle_rialto_server_eos(mSink);
         break;
     }
+    case firebolt::rialto::WebAudioPlayerState::IDLE:
+    case firebolt::rialto::WebAudioPlayerState::PLAYING:
+    case firebolt::rialto::WebAudioPlayerState::PAUSED:
+    {
+        rialto_web_audio_handle_rialto_server_state_changed(state);
+        break;
+    }
+    case firebolt::rialto::WebAudioPlayerState::UNKNOWN:
     default:
     {
+        GST_WARNING("Web audio player sent unknown state");
+        break;
     }
     }
 }

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -83,8 +83,8 @@ bool operator!=(const firebolt::rialto::WebAudioPcmConfig &lac, const firebolt::
 }
 } // namespace
 
-GStreamerWebAudioPlayerClient::GStreamerWebAudioPlayerClient(GstElement *appSink)
-    : mIsOpen(false), m_pushSamplesTimer(notifyPushSamplesCallback, this, "notifyPushSamplesCallback"), m_isEos(false), m_config({})
+GStreamerWebAudioPlayerClient::GStreamerWebAudioPlayerClient(RialtoWebAudioSink *sink)
+    : mIsOpen(false), m_pushSamplesTimer(notifyPushSamplesCallback, this, "notifyPushSamplesCallback"), m_isEos(false), m_config({}), mSink(sink)
 {
     mBackendQueue.start();
     mClientBackend = std::make_unique<firebolt::rialto::client::WebAudioClientBackend>();
@@ -402,8 +402,7 @@ void GStreamerWebAudioPlayerClient::notifyState(firebolt::rialto::WebAudioPlayer
     case firebolt::rialto::WebAudioPlayerState::END_OF_STREAM:
     {
         GST_INFO("Notify end of stream.");
-        // Notify EOS
-        //gst_element_post_message(mAppSink, gst_message_new_eos(GST_OBJECT_CAST(mAppSink)));
+        rialto_web_audio_handle_rialto_server_error(mSink);
         m_isEos = false;
         break;
     }
@@ -411,11 +410,7 @@ void GStreamerWebAudioPlayerClient::notifyState(firebolt::rialto::WebAudioPlayer
     {
         std::string errMessage = "Rialto server webaudio playback failed";
         GST_ERROR("%s", errMessage.c_str());
-        // Notify Error
-        //gst_element_post_message(mAppSink,
-        //                         gst_message_new_error(GST_OBJECT_CAST(mAppSink),
-        //                                               g_error_new_literal(GST_STREAM_ERROR, 0, errMessage.c_str()),
-        //                                               errMessage.c_str()));
+        rialto_web_audio_handle_rialto_server_eos(mSink);
         break;
     }
     default:

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -260,6 +260,20 @@ bool GStreamerWebAudioPlayerClient::setEos()
     return result;
 }
 
+bool GStreamerWebAudioPlayerClient::isOpen()
+{
+    GST_DEBUG("entry:");
+
+    bool result = false;
+    mBackendQueue.callInEventLoop(
+        [&]()
+        {
+            result = mIsOpen;
+        });
+
+    return result;
+}
+
 void GStreamerWebAudioPlayerClient::notifyPushSamplesTimerExpired()
 {
     mBackendQueue.callInEventLoop([&]() { pushSamples(); });

--- a/source/GStreamerWebAudioPlayerClient.cpp
+++ b/source/GStreamerWebAudioPlayerClient.cpp
@@ -343,10 +343,10 @@ void GStreamerWebAudioPlayerClient::getNextBufferData(GstBuffer *buf)
         return;
     }
 
-    uint32_t bufferSize = gst_buffer_get_size(buffer);
+    uint32_t bufferSize = gst_buffer_get_size(buf);
     GstMapInfo bufferMap;
 
-    if (!gst_buffer_map(buffer, &bufferMap, GST_MAP_READ))
+    if (!gst_buffer_map(buf, &bufferMap, GST_MAP_READ))
     {
         GST_ERROR("Could not map audio buffer");
         gst_buffer_unref(buf);

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -135,10 +135,13 @@ private:
     void pushSamples();
 
     /**
-     * @brief Get the next sample data buffer from gstreamer.
+     * @brief Get the data from the new sample.
      *
+     * @param[in] buf : The new buffer to be added.
+     *
+     * @retval true on success, false otherwise.
      */
-    void getNextBufferData(GstBuffer *buf);
+    bool getNextBufferData(GstBuffer *buf);
 
     /**
      * @brief Checks the config against that previously stored in the object.

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -20,7 +20,6 @@
 
 #include "MessageQueue.h"
 #include "Timer.h"
-#include "RialtoGStreamerWebAudioSink.h"
 #include "WebAudioClientBackendInterface.h"
 #include <MediaCommon.h>
 #include <condition_variable>
@@ -48,7 +47,7 @@ public:
      *
      * @param[in] sink : The WebAudioSink.
      */
-    GStreamerWebAudioPlayerClient(RialtoWebAudioSink *sink);
+    GStreamerWebAudioPlayerClient(GstElement *sink);
 
     /**
      * @brief Destructor.
@@ -164,7 +163,7 @@ private:
     /**
      * @brief The associated WebAudioSink from gstreamer.
      */
-    RialtoWebAudioSink *mSink;
+    GstElement *mSink;
 
     /**
      * @brief The push samples timer.

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -93,6 +93,13 @@ public:
     bool setEos();
 
     /**
+     * @brief Whether the backend has been opened or not.
+     *
+     * @retval true if open.
+     */
+    bool isOpen();
+
+    /**
      * @brief Notifies that there is a new sample in gstreamer.
      *
      * @retval true on success.

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -97,7 +97,7 @@ public:
      *
      * @retval true on success.
      */
-    bool notifyNewSample();
+    bool notifyNewSample(GstSample *sample);
 
     /**
      * @brief Notify push sample timer expiry.
@@ -124,7 +124,7 @@ private:
      * @brief Get the next sample data buffer from gstreamer.
      *
      */
-    void getNextBufferData();
+    void getNextBufferData(GstSample *sample);
 
     /**
      * @brief Checks the config against that previously stored in the object.
@@ -156,7 +156,7 @@ private:
     /**
      * @brief Appsink from gstreamer.
      */
-    GstElement *mAppSink;
+    //GstElement *mAppSink;
 
     /**
      * @brief The push samples timer.

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -109,6 +109,8 @@ public:
     /**
      * @brief Notifies that there is a new sample in gstreamer.
      *
+     * @param[in] buf : The new sample buffer.
+     *
      * @retval true on success.
      */
     bool notifyNewSample(GstBuffer *buf);

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -97,7 +97,7 @@ public:
      *
      * @retval true on success.
      */
-    bool notifyNewSample(GstSample *sample);
+    bool notifyNewSample(GstBuffer *buf);
 
     /**
      * @brief Notify push sample timer expiry.
@@ -124,7 +124,7 @@ private:
      * @brief Get the next sample data buffer from gstreamer.
      *
      */
-    void getNextBufferData(GstSample *sample);
+    void getNextBufferData(GstBuffer *buf);
 
     /**
      * @brief Checks the config against that previously stored in the object.

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -38,6 +38,13 @@
 #include <thread>
 #include <unistd.h>
 
+struct WebAudioSinkCallbacks
+{
+    std::function<void(const char *message)> errorCallback;
+    std::function<void(void)> eosCallback;
+    std::function<void(firebolt::rialto::WebAudioPlayerState)> stateChangedCallback;
+};
+
 class GStreamerWebAudioPlayerClient : public firebolt::rialto::IWebAudioPlayerClient,
                                       public std::enable_shared_from_this<GStreamerWebAudioPlayerClient>
 {
@@ -45,9 +52,9 @@ public:
     /**
      * @brief Constructor.
      *
-     * @param[in] sink : The WebAudioSink.
+     * @param[in] callbacks : The callbacks for the sink.
      */
-    GStreamerWebAudioPlayerClient(GstElement *sink);
+    GStreamerWebAudioPlayerClient(WebAudioSinkCallbacks callbacks);
 
     /**
      * @brief Destructor.
@@ -161,11 +168,6 @@ private:
     std::vector<uint8_t> mSampleDataBuffer;
 
     /**
-     * @brief The associated WebAudioSink from gstreamer.
-     */
-    GstElement *mSink;
-
-    /**
      * @brief The push samples timer.
      */
     Timer m_pushSamplesTimer;
@@ -204,4 +206,9 @@ private:
      * @brief The current web audio player config.
      */
     firebolt::rialto::WebAudioConfig m_config;
+
+    /**
+     * @brief The sink callbacks.
+     */
+    WebAudioSinkCallbacks m_callbacks;
 };

--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -20,6 +20,7 @@
 
 #include "MessageQueue.h"
 #include "Timer.h"
+#include "RialtoGStreamerWebAudioSink.h"
 #include "WebAudioClientBackendInterface.h"
 #include <MediaCommon.h>
 #include <condition_variable>
@@ -45,9 +46,9 @@ public:
     /**
      * @brief Constructor.
      *
-     * @param[in] appSink : Gstreamer appsink.
+     * @param[in] sink : The WebAudioSink.
      */
-    GStreamerWebAudioPlayerClient(GstElement *appSink);
+    GStreamerWebAudioPlayerClient(RialtoWebAudioSink *sink);
 
     /**
      * @brief Destructor.
@@ -161,9 +162,9 @@ private:
     std::vector<uint8_t> mSampleDataBuffer;
 
     /**
-     * @brief Appsink from gstreamer.
+     * @brief The associated WebAudioSink from gstreamer.
      */
-    //GstElement *mAppSink;
+    RialtoWebAudioSink *mSink;
 
     /**
      * @brief The push samples timer.

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -336,26 +336,29 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
                                          "Communicates with Rialto Server", "Sky");
 }
 
-void rialto_web_audio_handle_rialto_server_state_changed(RialtoWebAudioSink *sink, firebolt::rialto::WebAudioPlayerState state)
+void rialto_web_audio_handle_rialto_server_state_changed(GstElement *sink, firebolt::rialto::WebAudioPlayerState state)
 {
-    if (sink->priv->mCallbacks.stateChangedCallback)
+    RialtoWebAudioSink *webAudioSink = RIALTO_WEB_AUDIO_SINK(sink);
+    if (webAudioSink->priv->mCallbacks.stateChangedCallback)
     {
-        sink->priv->mCallbacks.stateChangedCallback(state);
+        webAudioSink->priv->mCallbacks.stateChangedCallback(state);
     }
 }
 
-void rialto_web_audio_handle_rialto_server_eos(RialtoWebAudioSink *sink)
+void rialto_web_audio_handle_rialto_server_eos(GstElement *sink)
 {
-    if (sink->priv->mCallbacks.eosCallback)
+    RialtoWebAudioSink *webAudioSink = RIALTO_WEB_AUDIO_SINK(sink);
+    if (webAudioSink->priv->mCallbacks.eosCallback)
     {
-        sink->priv->mCallbacks.eosCallback();
+        webAudioSink->priv->mCallbacks.eosCallback();
     }
 }
 
-void rialto_web_audio_handle_rialto_server_error(RialtoWebAudioSink *sink)
+void rialto_web_audio_handle_rialto_server_error(GstElement *sink)
 {
-    if (sink->priv->mCallbacks.errorCallback)
+    RialtoWebAudioSink *webAudioSink = RIALTO_WEB_AUDIO_SINK(sink);
+    if (webAudioSink->priv->mCallbacks.errorCallback)
     {
-        sink->priv->mCallbacks.errorCallback("Rialto server playback failed");
+        webAudioSink->priv->mCallbacks.errorCallback("Rialto server playback failed");
     }
 }

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -32,20 +32,6 @@ G_DEFINE_TYPE_WITH_CODE(RialtoWebAudioSink, rialto_web_audio_sink, GST_TYPE_ELEM
                             GST_DEBUG_CATEGORY_INIT(RialtoWebAudioSinkDebug, "rialtowebaudiosink", 0,
                                                     "rialto web audio sink"));
 
-GstFlowReturn rialto_web_audio_sink_sample_callback(GstElement *element, RialtoWebAudioSink *sink)
-{
-    bool res = sink->priv->mWebAudioClient->notifyNewSample();
-    if (res)
-    {
-        return GST_FLOW_OK;
-    }
-    else
-    {
-        GST_ERROR_OBJECT(element, "New sample notification failed");
-        return GST_FLOW_ERROR;
-    }
-}
-
 static gboolean rialto_web_audio_sink_send_event(GstElement *element, GstEvent *event)
 {
     RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(element);

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -227,7 +227,7 @@ static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstE
             {
                 sink->priv->mIsPlayingAsync = false;
                 gst_element_post_message(GST_ELEMENT_CAST(sink),
-                                        gst_message_new_async_done(GST_OBJECT_CAST(sink), GST_CLOCK_TIME_NONE));
+                                         gst_message_new_async_done(GST_OBJECT_CAST(sink), GST_CLOCK_TIME_NONE));
                 result = true;
             }
         }
@@ -291,7 +291,8 @@ static void rialto_web_audio_sink_init(RialtoWebAudioSink *sink)
 
     WebAudioSinkCallbacks callbacks;
     callbacks.eosCallback = std::bind(rialto_web_audio_sink_eos_handler, sink);
-    callbacks.stateChangedCallback = std::bind(rialto_web_audio_sink_rialto_state_changed_handler, sink, std::placeholders::_1);
+    callbacks.stateChangedCallback =
+        std::bind(rialto_web_audio_sink_rialto_state_changed_handler, sink, std::placeholders::_1);
     callbacks.errorCallback = std::bind(rialto_web_audio_sink_error_handler, sink, std::placeholders::_1);
 
     sink->priv->mRialtoControlClient = std::make_unique<firebolt::rialto::client::ControlBackend>();

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -164,6 +164,21 @@ static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstE
     return result;
 }
 
+static GstFlowReturn rialto_web_audio_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
+{
+    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(parent);
+    bool res = sink->priv->mWebAudioClient->notifyNewSample(buf);
+    if (res)
+    {
+        return GST_FLOW_OK;
+    }
+    else
+    {
+        GST_ERROR_OBJECT(sink, "Failed to push sample");
+        return GST_FLOW_ERROR;
+    }
+}
+
 static bool rialto_mse_base_sink_initialise_sinkpad(RialtoWebAudioSink *sink)
 {
     GstPadTemplate *pad_template =
@@ -189,21 +204,6 @@ static bool rialto_mse_base_sink_initialise_sinkpad(RialtoWebAudioSink *sink)
     return true;
 }
 
-static GstFlowReturn rialto_web_audio_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
-{
-    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(parent);
-    bool res = sink->priv->mWebAudioClient->notifyNewSample(buf);
-    if (res)
-    {
-        return GST_FLOW_OK;
-    }
-    else
-    {
-        GST_ERROR_OBJECT(sink, "Failed to push sample");
-        return GST_FLOW_ERROR;
-    }
-}
-
 static void rialto_web_audio_sink_init(RialtoWebAudioSink *sink)
 {
     sink->priv = static_cast<RialtoWebAudioSinkPrivate *>(rialto_web_audio_sink_get_instance_private(sink));
@@ -213,7 +213,7 @@ static void rialto_web_audio_sink_init(RialtoWebAudioSink *sink)
 
     sink->priv->mWebAudioClient = std::make_shared<GStreamerWebAudioPlayerClient>(GST_ELEMENT(sink));
 
-    if (!rialto_mse_base_sink_initialise_sinkpad(RIALTO_MSE_BASE_SINK(sink)))
+    if (!rialto_mse_base_sink_initialise_sinkpad(RIALTO_WEB_AUDIO_SINK(sink)))
     {
         GST_ERROR_OBJECT(sink, "Failed to initialise AUDIO sink. Sink pad initialisation failed.");
         return;

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -196,7 +196,6 @@ static GstStateChangeReturn rialto_web_audio_sink_change_state(GstElement *eleme
 static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstEvent *event)
 {
     RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(parent);
-    GST_ERROR("lukewill: Event %s", gst_event_type_get_name(GST_EVENT_TYPE(event)));
     bool result = false;
     switch (GST_EVENT_TYPE(event))
     {

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -180,14 +180,15 @@ static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstE
 
 static GstFlowReturn rialto_web_audio_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
 {
-    bool res = sink->priv->mWebAudioClient->notifyNewSample();
+    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(parent);
+    bool res = sink->priv->mWebAudioClient->notifyNewSample(buf);
     if (res)
     {
         return GST_FLOW_OK;
     }
     else
     {
-        GST_ERROR_OBJECT(element, "Failed to push sample");
+        GST_ERROR_OBJECT(sink, "Failed to push sample");
         return GST_FLOW_ERROR;
     }
 }
@@ -200,8 +201,6 @@ static void rialto_web_audio_sink_init(RialtoWebAudioSink *sink)
     sink->priv->mRialtoControlClient = std::make_unique<firebolt::rialto::client::ControlBackend>();
 
     sink->priv->mWebAudioClient = std::make_shared<GStreamerWebAudioPlayerClient>(GST_ELEMENT(sink));
-
-    rialto_web_audio_sink_initialise_appsink(sink);
 
     GstPad *sinkPad = gst_element_get_static_pad(GST_ELEMENT_CAST(sink), "sink");
     if (sinkPad)

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -24,6 +24,7 @@
 #include <gst/gst.h>
 #include <queue>
 #include <functional>
+#include <MediaCommon.h>
 
 G_BEGIN_DECLS
 
@@ -66,8 +67,8 @@ struct _RialtoWebAudioSinkClass
 
 GType rialto_web_audio_sink_get_type(void);
 
-void rialto_web_audio_handle_rialto_server_state_changed(RialtoWebAudioSink *sink, firebolt::rialto::WebAudioPlayerState state);
-void rialto_web_audio_handle_rialto_server_eos(RialtoWebAudioSink *sink);
-void rialto_web_audio_handle_rialto_server_error(RialtoWebAudioSink *sink);
+void rialto_web_audio_handle_rialto_server_state_changed(GstElement *sink, firebolt::rialto::WebAudioPlayerState state);
+void rialto_web_audio_handle_rialto_server_eos(GstElement *sink);
+void rialto_web_audio_handle_rialto_server_error(GstElement *sink);
 
 G_END_DECLS

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -39,19 +39,11 @@ typedef struct _RialtoWebAudioSink RialtoWebAudioSink;
 typedef struct _RialtoWebAudioSinkClass RialtoWebAudioSinkClass;
 typedef struct _RialtoWebAudioSinkPrivate RialtoWebAudioSinkPrivate;
 
-struct RialtoGStreamerWebAudioSinkCallbacks
-{
-    std::function<void(const char *message)> errorCallback;
-    std::function<void(void)> eosCallback;
-    std::function<void(firebolt::rialto::WebAudioPlayerState)> stateChangedCallback;
-};
-
 struct _RialtoWebAudioSinkPrivate
 {
     std::shared_ptr<GStreamerWebAudioPlayerClient> mWebAudioClient;
     std::unique_ptr<firebolt::rialto::client::ControlBackendInterface> mRialtoControlClient;
     bool mIsPlayingAsync = false;
-    RialtoGStreamerWebAudioSinkCallbacks mCallbacks;
 };
 
 struct _RialtoWebAudioSink

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -21,10 +21,7 @@
 #include "ControlBackendInterface.h"
 #include "GStreamerWebAudioPlayerClient.h"
 #include <MediaCommon.h>
-#include <functional>
-#include <gst/base/gstbasesink.h>
 #include <gst/gst.h>
-#include <queue>
 
 G_BEGIN_DECLS
 

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -41,6 +41,7 @@ struct _RialtoWebAudioSinkPrivate
 {
     std::shared_ptr<GStreamerWebAudioPlayerClient> mWebAudioClient;
     std::unique_ptr<firebolt::rialto::client::ControlBackendInterface> mRialtoControlClient;
+    bool mIsStateCommitNeeded = false;
 };
 
 struct _RialtoWebAudioSink

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -20,11 +20,11 @@
 
 #include "ControlBackendInterface.h"
 #include "GStreamerWebAudioPlayerClient.h"
+#include <MediaCommon.h>
+#include <functional>
 #include <gst/base/gstbasesink.h>
 #include <gst/gst.h>
 #include <queue>
-#include <functional>
-#include <MediaCommon.h>
 
 G_BEGIN_DECLS
 

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -41,7 +41,7 @@ struct _RialtoWebAudioSinkPrivate
 {
     std::shared_ptr<GStreamerWebAudioPlayerClient> mWebAudioClient;
     std::unique_ptr<firebolt::rialto::client::ControlBackendInterface> mRialtoControlClient;
-    bool mIsStateCommitNeeded = false;
+    bool mIsPlayingAsync = false;
 };
 
 struct _RialtoWebAudioSink

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -22,6 +22,7 @@
 #include "GStreamerWebAudioPlayerClient.h"
 #include <gst/base/gstbasesink.h>
 #include <gst/gst.h>
+#include <queue>
 
 G_BEGIN_DECLS
 
@@ -38,20 +39,19 @@ typedef struct _RialtoWebAudioSinkPrivate RialtoWebAudioSinkPrivate;
 
 struct _RialtoWebAudioSinkPrivate
 {
-    GstElement *mAppSink;
     std::shared_ptr<GStreamerWebAudioPlayerClient> mWebAudioClient;
     std::unique_ptr<firebolt::rialto::client::ControlBackendInterface> mRialtoControlClient;
 };
 
 struct _RialtoWebAudioSink
 {
-    GstBin parent;
+    GstElement parent;
     RialtoWebAudioSinkPrivate *priv;
 };
 
 struct _RialtoWebAudioSinkClass
 {
-    GstBinClass parent_class;
+    GstElementClass parent_class;
 };
 
 GType rialto_web_audio_sink_get_type(void);

--- a/source/RialtoGStreamerWebAudioSink.h
+++ b/source/RialtoGStreamerWebAudioSink.h
@@ -23,6 +23,7 @@
 #include <gst/base/gstbasesink.h>
 #include <gst/gst.h>
 #include <queue>
+#include <functional>
 
 G_BEGIN_DECLS
 
@@ -37,11 +38,19 @@ typedef struct _RialtoWebAudioSink RialtoWebAudioSink;
 typedef struct _RialtoWebAudioSinkClass RialtoWebAudioSinkClass;
 typedef struct _RialtoWebAudioSinkPrivate RialtoWebAudioSinkPrivate;
 
+struct RialtoGStreamerWebAudioSinkCallbacks
+{
+    std::function<void(const char *message)> errorCallback;
+    std::function<void(void)> eosCallback;
+    std::function<void(firebolt::rialto::WebAudioPlayerState)> stateChangedCallback;
+};
+
 struct _RialtoWebAudioSinkPrivate
 {
     std::shared_ptr<GStreamerWebAudioPlayerClient> mWebAudioClient;
     std::unique_ptr<firebolt::rialto::client::ControlBackendInterface> mRialtoControlClient;
     bool mIsPlayingAsync = false;
+    RialtoGStreamerWebAudioSinkCallbacks mCallbacks;
 };
 
 struct _RialtoWebAudioSink
@@ -56,5 +65,9 @@ struct _RialtoWebAudioSinkClass
 };
 
 GType rialto_web_audio_sink_get_type(void);
+
+void rialto_web_audio_handle_rialto_server_state_changed(RialtoWebAudioSink *sink, firebolt::rialto::WebAudioPlayerState state);
+void rialto_web_audio_handle_rialto_server_eos(RialtoWebAudioSink *sink);
+void rialto_web_audio_handle_rialto_server_error(RialtoWebAudioSink *sink);
 
 G_END_DECLS


### PR DESCRIPTION
Summary: Remove the basesink from rialtowebaudiosink to fix WebAudio playback for Amlogic.
Type: BugFix
Test Plan: YouTube Cert Tests, NPLB Tests
Jira: RIALTO-166