### PR TITLE
Add ts offset property, not supported by rialto

### DIFF
--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -255,7 +255,8 @@ static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GV
     {
     case PROP_TS_OFFSET:
     {
-        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the syncronisation of sources");
+        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
+                                 "syncronisation of sources");
         break;
     }
 
@@ -273,7 +274,8 @@ static void rialto_web_audio_sink_set_property(GObject *object, guint propId, co
     {
     case PROP_TS_OFFSET:
     {
-        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the syncronisation of sources");
+        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
+                                 "syncronisation of sources");
         break;
     }
     default:
@@ -371,7 +373,10 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
     elementClass->send_event = rialto_web_audio_sink_send_event;
 
     g_object_class_install_property(gobjectClass, PROP_TS_OFFSET,
-                                    g_param_spec_int64("ts-offset", "ts-offset", "Not supported, RialtoWebAudioSink does not require the syncronisation of sources", G_MININT64, G_MAXINT64, 0, GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+                                    g_param_spec_int64("ts-offset",
+                                                       "ts-offset", "Not supported, RialtoWebAudioSink does not require the syncronisation of sources",
+                                                       G_MININT64, G_MAXINT64, 0,
+                                                       GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
     rialto_web_audio_sink_setup_supported_caps(elementClass);
 
     gst_element_class_set_details_simple(elementClass, "Rialto Web Audio Sink", "Decoder/Audio/Sink/Audio",

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -293,8 +293,8 @@ static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GV
     {
     case PROP_TS_OFFSET:
     {
-        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
-                                 "syncronisation of sources");
+        GST_INFO_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
+                                "syncronisation of sources");
         break;
     }
 
@@ -312,8 +312,8 @@ static void rialto_web_audio_sink_set_property(GObject *object, guint propId, co
     {
     case PROP_TS_OFFSET:
     {
-        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
-                                 "syncronisation of sources");
+        GST_INFO_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
+                                "syncronisation of sources");
         break;
     }
     default:

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -251,23 +251,11 @@ static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstE
 
 static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GValue *value, GParamSpec *pspec)
 {
-    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(object);
-    RialtoWebAudioSinkPrivate *priv = sink->parent.priv;
-    if (!sink || !priv)
-    {
-        GST_ERROR_OBJECT(object, "Sink not initalised");
-        return;
-    }
     switch (propId)
     {
     case PROP_TS_OFFSET:
     {
-        if (!priv->m_webAudioClient)
-        {
-            GST_WARNING_OBJECT(object, "missing web audio client");
-            return;
-        }
-        //TODO GET OFFSET
+        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the syncronisation of sources");
         break;
     }
 
@@ -281,24 +269,11 @@ static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GV
 
 static void rialto_web_audio_sink_set_property(GObject *object, guint propId, const GValue *value, GParamSpec *pspec)
 {
-    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(object);
-    RialtoWebAudioSinkPrivate *priv = sink->parent.priv;
-    if (!sink || !priv)
-    {
-        GST_ERROR_OBJECT(object, "Sink not initalised");
-        return;
-    }
-
     switch (propId)
     {
     case PROP_TS_OFFSET:
     {
-        if (!priv->m_webAudioClient)
-        {
-            GST_WARNING_OBJECT(object, "missing web audio client");
-            return;
-        }
-        //TODO SET OFFSET
+        GST_ERROR_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the syncronisation of sources");
         break;
     }
     default:
@@ -396,7 +371,7 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
     elementClass->send_event = rialto_web_audio_sink_send_event;
 
     g_object_class_install_property(gobjectClass, PROP_TS_OFFSET,
-                                    g_param_spec_int64("ts-offset", "ts-offset", "Timestamp offset in nanoseconds", G_MININT64, G_MAXINT64, 0, GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+                                    g_param_spec_int64("ts-offset", "ts-offset", "Not supported, RialtoWebAudioSink does not require the syncronisation of sources", G_MININT64, G_MAXINT64, 0, GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
     rialto_web_audio_sink_setup_supported_caps(elementClass);
 
     gst_element_class_set_details_simple(elementClass, "Rialto Web Audio Sink", "Decoder/Audio/Sink/Audio",

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -406,6 +406,8 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
                                    "Sky");
 
     gobjectClass->finalize = rialto_web_audio_sink_finalize;
+    gobjectClass->get_property = rialto_web_audio_sink_get_property;
+    gobjectClass->set_property = rialto_web_audio_sink_set_property;
 
     elementClass->change_state = rialto_web_audio_sink_change_state;
     elementClass->send_event = rialto_web_audio_sink_send_event;

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -31,6 +31,12 @@ G_DEFINE_TYPE_WITH_CODE(RialtoWebAudioSink, rialto_web_audio_sink, GST_TYPE_ELEM
                         G_ADD_PRIVATE(RialtoWebAudioSink)
                             GST_DEBUG_CATEGORY_INIT(RialtoWebAudioSinkDebug, "rialtowebaudiosink", 0,
                                                     "rialto web audio sink"));
+enum
+{
+    PROP_0,
+    PROP_TS_OFFSET,
+    PROP_LAST
+};
 
 static void rialto_web_audio_sink_eos_handler(RialtoWebAudioSink *sink)
 {
@@ -243,6 +249,66 @@ static gboolean rialto_web_audio_sink_event(GstPad *pad, GstObject *parent, GstE
     return result;
 }
 
+static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GValue *value, GParamSpec *pspec)
+{
+    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(object);
+    RialtoWebAudioSinkPrivate *priv = sink->parent.priv;
+    if (!sink || !priv)
+    {
+        GST_ERROR_OBJECT(object, "Sink not initalised");
+        return;
+    }
+    switch (propId)
+    {
+    case PROP_TS_OFFSET:
+    {
+        if (!priv->m_webAudioClient)
+        {
+            GST_WARNING_OBJECT(object, "missing web audio client");
+            return;
+        }
+        //TODO GET OFFSET
+        break;
+    }
+
+    default:
+    {
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, pspec);
+        break;
+    }
+    }
+}
+
+static void rialto_web_audio_sink_set_property(GObject *object, guint propId, const GValue *value, GParamSpec *pspec)
+{
+    RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(object);
+    RialtoWebAudioSinkPrivate *priv = sink->parent.priv;
+    if (!sink || !priv)
+    {
+        GST_ERROR_OBJECT(object, "Sink not initalised");
+        return;
+    }
+
+    switch (propId)
+    {
+    case PROP_TS_OFFSET:
+    {
+        if (!priv->m_webAudioClient)
+        {
+            GST_WARNING_OBJECT(object, "missing web audio client");
+            return;
+        }
+        //TODO SET OFFSET
+        break;
+    }
+    default:
+    {
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, pspec);
+        break;
+    }
+    }
+}
+
 static GstFlowReturn rialto_web_audio_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)
 {
     RialtoWebAudioSink *sink = RIALTO_WEB_AUDIO_SINK(parent);
@@ -329,6 +395,8 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
     elementClass->change_state = rialto_web_audio_sink_change_state;
     elementClass->send_event = rialto_web_audio_sink_send_event;
 
+    g_object_class_install_property(gobjectClass, PROP_TS_OFFSET,
+                                    g_param_spec_int64("ts-offset", "ts-offset", "Timestamp offset in nanoseconds", G_MININT64, G_MAXINT64, 0, GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
     rialto_web_audio_sink_setup_supported_caps(elementClass);
 
     gst_element_class_set_details_simple(elementClass, "Rialto Web Audio Sink", "Decoder/Audio/Sink/Audio",

--- a/source/RialtoGStreamerWebAudioSink.cpp
+++ b/source/RialtoGStreamerWebAudioSink.cpp
@@ -294,7 +294,7 @@ static void rialto_web_audio_sink_get_property(GObject *object, guint propId, GV
     case PROP_TS_OFFSET:
     {
         GST_INFO_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
-                                "syncronisation of sources");
+                                "synchronisation of sources");
         break;
     }
 
@@ -313,7 +313,7 @@ static void rialto_web_audio_sink_set_property(GObject *object, guint propId, co
     case PROP_TS_OFFSET:
     {
         GST_INFO_OBJECT(object, "ts-offset property not supported, RialtoWebAudioSink does not require the "
-                                "syncronisation of sources");
+                                "synchronisation of sources");
         break;
     }
     default:
@@ -414,7 +414,7 @@ static void rialto_web_audio_sink_class_init(RialtoWebAudioSinkClass *klass)
 
     g_object_class_install_property(gobjectClass, PROP_TS_OFFSET,
                                     g_param_spec_int64("ts-offset",
-                                                       "ts-offset", "Not supported, RialtoWebAudioSink does not require the syncronisation of sources",
+                                                       "ts-offset", "Not supported, RialtoWebAudioSink does not require the synchronisation of sources",
                                                        G_MININT64, G_MAXINT64, 0,
                                                        GParamFlags(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
     rialto_web_audio_sink_setup_supported_caps(elementClass);


### PR DESCRIPTION
Summary: Gstreamer complains that the RialtoWebAudioSink does not define the ts-offset property, this property is not required for WebAudio as there is no synchronisation of sources. This change implements the ts-offset property but logs an error is it is been used.
Type: Bufix
Test Plan: YouTube Cert Tests, NPLB Tests
Jira: RIALTO-168