### PR TITLE
Fix spelling of summary

### DIFF
--- a/.github/workflows/commit_message_format.yml
+++ b/.github/workflows/commit_message_format.yml
@@ -41,7 +41,7 @@ jobs:
           message: |
             Pull request must be merged with a description containing the required fields,
 
-            Summery:
+            Summary:
             Type: Feature/Fix/Cleanup
             Test Plan:
             Jira:
@@ -50,18 +50,18 @@ jobs:
 
             Description can be changed by editing the top comment on your pull request and making a new commit.
 
-      # Check PR description for 'Summery:' field.
-      - name: Match 'Summery:' 
+      # Check PR description for 'Summary:' field.
+      - name: Match 'Summary:' 
         uses: actions-ecosystem/action-regex-match@v2
-        id: summery-match
+        id: summary-match
         if: failure() || success()
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: 'Summery:\s*[\s\S]*?'
+          regex: 'Summary:\s*[\s\S]*?'
           flags: gm
 
-      - name: Check 'Summery:' 
-        if: (failure() || success()) && (steps.summery-match.outputs.match == '')
+      - name: Check 'Summary:' 
+        if: (failure() || success()) && (steps.summary-match.outputs.match == '')
         run: exit 1
   
       # Check PR description for 'Type: Feature|Fix|Cleanup' field.

--- a/.github/workflows/valgrind_ut.yml
+++ b/.github/workflows/valgrind_ut.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           csvinput: ${{ steps.csv-memory.outputs.content }}
 
-      # Add table to the summery
+      # Add table to the summary
       - name: Create results table
         if: failure()
         run: |


### PR DESCRIPTION
Summary: Summary is spelt wrong in commit-message formatter and valgrind action.
Type: Fix
Test Plan: Actions succeed
Jira: RIALTO-362