### PR TITLE
Rialto 368 use weak ptr for web audio config

### DIFF
--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -145,7 +145,7 @@ private:
      *
      * @retval true if this is a new config.
      */
-    bool isNewConfig(const std::string &audioMimeType, const firebolt::rialto::WebAudioConfig &config);
+    bool isNewConfig(const std::string &audioMimeType, std::weak_ptr<const firebolt::rialto::WebAudioConfig> config);
 
     /**
      * @brief Backend message queue.

--- a/source/WebAudioClientBackend.h
+++ b/source/WebAudioClientBackend.h
@@ -32,7 +32,7 @@ public:
     ~WebAudioClientBackend() final { m_webAudioPlayerBackend.reset(); }
 
     bool createWebAudioBackend(std::weak_ptr<IWebAudioPlayerClient> client, const std::string &audioMimeType,
-                               const uint32_t priority, const WebAudioConfig *config) override
+                               const uint32_t priority, std::weak_ptr<const WebAudioConfig> config) override
     {
         m_webAudioPlayerBackend =
             firebolt::rialto::IWebAudioPlayerFactory::createFactory()->createWebAudioPlayer(client, audioMimeType,

--- a/source/WebAudioClientBackendInterface.h
+++ b/source/WebAudioClientBackendInterface.h
@@ -27,7 +27,7 @@ class WebAudioClientBackendInterface
 public:
     virtual ~WebAudioClientBackendInterface() = default;
     virtual bool createWebAudioBackend(std::weak_ptr<IWebAudioPlayerClient> client, const std::string &audioMimeType,
-                                       const uint32_t priority, const WebAudioConfig *config) = 0;
+                                       const uint32_t priority, std::weak_ptr<const WebAudioConfig> config) = 0;
     virtual void destroyWebAudioBackend() = 0;
 
     virtual bool play() = 0;

--- a/tests/mocks/WebAudioClientBackendMock.h
+++ b/tests/mocks/WebAudioClientBackendMock.h
@@ -29,7 +29,7 @@ class WebAudioClientBackendMock : public WebAudioClientBackendInterface
 public:
     MOCK_METHOD(bool, createWebAudioBackend,
                 (std::weak_ptr<IWebAudioPlayerClient> client, const std::string &audioMimeType, const uint32_t priority,
-                 const WebAudioConfig *config),
+                 std::weak_ptr<const WebAudioConfig> config),
                 (override));
     MOCK_METHOD(void, destroyWebAudioBackend, (), (override));
     MOCK_METHOD(bool, play, (), (override));

--- a/tests/mocks/WebAudioPlayerMock.h
+++ b/tests/mocks/WebAudioPlayerMock.h
@@ -29,7 +29,8 @@ class WebAudioPlayerFactoryMock : public IWebAudioPlayerFactory
 public:
     MOCK_METHOD(std::unique_ptr<IWebAudioPlayer>, createWebAudioPlayer,
                 (std::weak_ptr<IWebAudioPlayerClient> client, const std::string &audioMimeType, const uint32_t priority,
-                 const WebAudioConfig *config, std::weak_ptr<client::IWebAudioPlayerIpcFactory> webAudioPlayerIpcFactory,
+                 std::weak_ptr<const WebAudioConfig> config,
+                 std::weak_ptr<client::IWebAudioPlayerIpcFactory> webAudioPlayerIpcFactory,
                  std::weak_ptr<client::IClientController> clientController),
                 (const, override));
 };

--- a/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
+++ b/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "GStreamerWebAudioPlayerClient.h"
+#include "Matchers.h"
 #include "MessageQueueMock.h"
 #include "RialtoGstTest.h"
 #include "TimerFactoryMock.h"

--- a/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
+++ b/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
@@ -79,9 +79,8 @@ constexpr std::chrono::milliseconds kTimeout{100};
 constexpr auto kTimerType{TimerType::ONE_SHOT};
 MATCHER_P(WebAudioConfigMatcher, config, "")
 {
-    return arg && arg->pcm.rate == config.rate && arg->pcm.channels == config.channels &&
-           arg->pcm.sampleSize == config.sampleSize && arg->pcm.isBigEndian == config.isBigEndian &&
-           arg->pcm.isSigned == config.isSigned && arg->pcm.isFloat == config.isFloat;
+    std::shared_ptr<const firebolt::rialto::WebAudioConfig> argConfig = arg.lock();
+    return argConfig && argConfig->pcm == config;
 }
 } // namespace
 

--- a/tests/ut/Matchers.cpp
+++ b/tests/ut/Matchers.cpp
@@ -34,6 +34,6 @@ bool operator==(const AudioConfig &lhs, const AudioConfig &rhs)
 bool operator==(const WebAudioPcmConfig &lhs, const WebAudioPcmConfig &rhs)
 {
     return lhs.rate == rhs.rate && lhs.channels == rhs.channels && lhs.sampleSize == rhs.sampleSize &&
-        lhs.isBigEndian == rhs.isBigEndian && lhs.isSigned == rhs.isSigned && lhs.isFloat == rhs.isFloat;
+           lhs.isBigEndian == rhs.isBigEndian && lhs.isSigned == rhs.isSigned && lhs.isFloat == rhs.isFloat;
 }
 } // namespace firebolt::rialto

--- a/tests/ut/Matchers.cpp
+++ b/tests/ut/Matchers.cpp
@@ -30,4 +30,10 @@ bool operator==(const AudioConfig &lhs, const AudioConfig &rhs)
     // Skip checking codecSpecificConfig, as it is returned by gstreamer function
     return lhs.numberOfChannels == rhs.numberOfChannels && lhs.sampleRate == rhs.sampleRate;
 }
+
+bool operator==(const WebAudioPcmConfig &lhs, const WebAudioPcmConfig &rhs)
+{
+    return lhs.rate == rhs.rate && lhs.channels == rhs.channels && lhs.sampleSize == rhs.sampleSize &&
+        lhs.isBigEndian == rhs.isBigEndian && lhs.isSigned == rhs.isSigned && lhs.isFloat == rhs.isFloat;
+}
 } // namespace firebolt::rialto

--- a/tests/ut/Matchers.h
+++ b/tests/ut/Matchers.h
@@ -25,6 +25,7 @@ namespace firebolt::rialto
 {
 bool operator==(const VideoRequirements &lhs, const VideoRequirements &rhs);
 bool operator==(const AudioConfig &lhs, const AudioConfig &rhs);
+bool operator==(const WebAudioPcmConfig &lhs, const WebAudioPcmConfig &rhs);
 } // namespace firebolt::rialto
 
 #endif // MATCHERS_H

--- a/tests/ut/WebAudioClientBackendTests.cpp
+++ b/tests/ut/WebAudioClientBackendTests.cpp
@@ -40,6 +40,12 @@ constexpr uint32_t kPriority{123};
 constexpr firebolt::rialto::WebAudioConfig kConfig{firebolt::rialto::WebAudioPcmConfig{1, 2, 3, false, true, false}};
 constexpr uint32_t kFrames{18};
 constexpr double kVolume{0.5};
+
+MATCHER_P(webAudioConfigMatcher, config, "")
+{
+    std::shared_ptr<const firebolt::rialto::WebAudioConfig> argConfig = arg.lock();
+    return argConfig && argConfig->pcm == config->pcm;
+}
 } // namespace
 
 class WebAudioClientBackendTests : public testing::Test
@@ -50,21 +56,25 @@ public:
     std::unique_ptr<StrictMock<WebAudioPlayerMock>> m_playerMock{std::make_unique<StrictMock<WebAudioPlayerMock>>()};
     std::shared_ptr<StrictMock<WebAudioPlayerClientMock>> m_clientMock{
         std::make_shared<StrictMock<WebAudioPlayerClientMock>>()};
+    std::shared_ptr<firebolt::rialto::WebAudioConfig> m_config =
+        std::make_shared<firebolt::rialto::WebAudioConfig>(kConfig);
     WebAudioClientBackend m_sut;
 
     bool createBackend()
     {
-        EXPECT_CALL(*m_playerFactoryMock, createWebAudioPlayer(_, kAudioMimeType, kPriority, &kConfig, _, _))
+        EXPECT_CALL(*m_playerFactoryMock,
+                    createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config), _, _))
             .WillOnce(Return(ByMove(std::move(m_playerMock))));
-        return m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, &kConfig);
+        return m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, m_config);
     }
 };
 
 TEST_F(WebAudioClientBackendTests, ShouldFailToCreateBackend)
 {
-    EXPECT_CALL(*m_playerFactoryMock, createWebAudioPlayer(_, kAudioMimeType, kPriority, &kConfig, _, _))
+    EXPECT_CALL(*m_playerFactoryMock,
+                createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config), _, _))
         .WillOnce(Return(nullptr));
-    EXPECT_FALSE(m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, &kConfig));
+    EXPECT_FALSE(m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, m_config));
 }
 
 TEST_F(WebAudioClientBackendTests, ShouldCreateBackend)

--- a/tests/ut/WebAudioClientBackendTests.cpp
+++ b/tests/ut/WebAudioClientBackendTests.cpp
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "Matchers.h"
 #include "WebAudioClientBackend.h"
 #include "WebAudioPlayerClientMock.h"
 #include "WebAudioPlayerMock.h"


### PR DESCRIPTION
Summary: Use weak_ptr for passing WebAudioConfig instead of c-style pointer
Type: Cleanup
Test Plan: Passed unit tests, run on Sky stream UK box, and passed the ytcert manual webaudio test
Jira: RIALTO-368