### PR TITLE
Revert mock injection interface changes

### DIFF
--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -28,9 +28,7 @@ class MediaPipelineFactoryMock : public IMediaPipelineFactory
 {
 public:
     MOCK_METHOD(std::unique_ptr<IMediaPipeline>, createMediaPipeline,
-                (std::weak_ptr<IMediaPipelineClient> client, const VideoRequirements &videoRequirements,
-                 std::weak_ptr<client::IMediaPipelineIpcFactory> mediaPipelineIpcFactory,
-                 std::weak_ptr<client::IClientController> clientController),
+                (std::weak_ptr<IMediaPipelineClient> client, const VideoRequirements &videoRequirements),
                 (const, override));
 };
 

--- a/tests/mocks/WebAudioPlayerMock.h
+++ b/tests/mocks/WebAudioPlayerMock.h
@@ -29,9 +29,7 @@ class WebAudioPlayerFactoryMock : public IWebAudioPlayerFactory
 public:
     MOCK_METHOD(std::unique_ptr<IWebAudioPlayer>, createWebAudioPlayer,
                 (std::weak_ptr<IWebAudioPlayerClient> client, const std::string &audioMimeType, const uint32_t priority,
-                 std::weak_ptr<const WebAudioConfig> config,
-                 std::weak_ptr<client::IWebAudioPlayerIpcFactory> webAudioPlayerIpcFactory,
-                 std::weak_ptr<client::IClientController> clientController),
+                 std::weak_ptr<const WebAudioConfig> config),
                 (const, override));
 };
 

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -58,7 +58,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldFailToReachPausedStateWhenMediaPipeline
     RialtoMSEBaseSink *audioSink = createAudioSink();
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements)).WillOnce(Return(nullptr));
     EXPECT_EQ(GST_STATE_CHANGE_FAILURE, gst_element_set_state(pipeline, GST_STATE_PAUSED));
     EXPECT_EQ(GST_STATE_CHANGE_SUCCESS, gst_element_set_state(pipeline, GST_STATE_NULL));
 

--- a/tests/ut/GstreamerMseVideoSinkTests.cpp
+++ b/tests/ut/GstreamerMseVideoSinkTests.cpp
@@ -59,7 +59,7 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldFailToReachPausedStateWhenMediaPipeline
     RialtoMSEBaseSink *videoSink = createVideoSink();
     GstElement *pipeline = createPipelineWithSink(videoSink);
 
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements)).WillOnce(Return(nullptr));
     EXPECT_EQ(GST_STATE_CHANGE_FAILURE, gst_element_set_state(pipeline, GST_STATE_PAUSED));
     EXPECT_EQ(GST_STATE_CHANGE_SUCCESS, gst_element_set_state(pipeline, GST_STATE_NULL));
 

--- a/tests/ut/GstreamerWebAudioSinkTests.cpp
+++ b/tests/ut/GstreamerWebAudioSinkTests.cpp
@@ -79,7 +79,7 @@ public:
         EXPECT_CALL(m_playerMock, getDeviceInfo(_, _, _))
             .WillOnce(DoAll(SetArgReferee<0>(kFrames), SetArgReferee<1>(kMaximumFrames),
                             SetArgReferee<2>(kSupportDeferredPlay), Return(true)));
-        EXPECT_CALL(*m_playerFactoryMock, createWebAudioPlayer(_, kMimeType, kPriority, _, _, _))
+        EXPECT_CALL(*m_playerFactoryMock, createWebAudioPlayer(_, kMimeType, kPriority, _))
             .WillOnce(Return(ByMove(std::move(m_player))));
         setCaps(sink, caps);
         gst_caps_unref(caps);

--- a/tests/ut/MediaPlayerClientBackendTests.cpp
+++ b/tests/ut/MediaPlayerClientBackendTests.cpp
@@ -58,7 +58,7 @@ public:
 
     void initializeMediaPipeline()
     {
-        EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kVideoRequirements, _, _))
+        EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kVideoRequirements))
             .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
         m_sut.createMediaPlayerBackend(m_mediaPipelineClientMock, kVideoRequirements.maxWidth,
                                        kVideoRequirements.maxHeight);
@@ -72,7 +72,7 @@ TEST_F(MediaPlayerClientBackendTests, MediaPlayerShouldNotBeCreated)
 
 TEST_F(MediaPlayerClientBackendTests, ShouldFailToCreateMediaPipeline)
 {
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kVideoRequirements, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kVideoRequirements)).WillOnce(Return(nullptr));
     m_sut.createMediaPlayerBackend(m_mediaPipelineClientMock, kVideoRequirements.maxWidth, kVideoRequirements.maxHeight);
     EXPECT_FALSE(m_sut.isMediaPlayerBackendCreated());
 }

--- a/tests/ut/MediaPlayerManagerTests.cpp
+++ b/tests/ut/MediaPlayerManagerTests.cpp
@@ -59,28 +59,28 @@ TEST_F(MediaPlayerManagerTests, ShouldNotHaveControlWhenClientIsNotAttached)
 TEST_F(MediaPlayerManagerTests, ShouldAttachMediaPlayerClient)
 {
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
 }
 
 TEST_F(MediaPlayerManagerTests, ShouldFailToAttachMediaPlayerClient)
 {
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _)).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _)).WillOnce(Return(nullptr));
     EXPECT_FALSE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
 }
 
 TEST_F(MediaPlayerManagerTests, ShouldAttachMediaPlayerClientForAnotherGstObject)
 {
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
 
     m_mediaPipelineMock = std::make_unique<StrictMock<MediaPipelineMock>>();
     GstObject anotherObject{};
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&anotherObject, kMaxVideoWidth, kMaxVideoHeight));
 }
@@ -88,7 +88,7 @@ TEST_F(MediaPlayerManagerTests, ShouldAttachMediaPlayerClientForAnotherGstObject
 TEST_F(MediaPlayerManagerTests, ShouldHaveControl)
 {
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
     EXPECT_TRUE(m_sut.hasControl());
@@ -97,7 +97,7 @@ TEST_F(MediaPlayerManagerTests, ShouldHaveControl)
 TEST_F(MediaPlayerManagerTests, SecondMediaPlayerManagerShouldAttachMediaPlayerClient)
 {
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
     MediaPlayerManager secondSut;
@@ -107,7 +107,7 @@ TEST_F(MediaPlayerManagerTests, SecondMediaPlayerManagerShouldAttachMediaPlayerC
 TEST_F(MediaPlayerManagerTests, SecondMediaPlayerManagerShouldFailToAcquireControl)
 {
     EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
         .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
     EXPECT_TRUE(m_sut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
     EXPECT_TRUE(m_sut.hasControl());
@@ -121,7 +121,7 @@ TEST_F(MediaPlayerManagerTests, ShouldAcquireControl)
     {
         MediaPlayerManager secondSut;
         EXPECT_CALL(*m_mediaPipelineMock, load(_, _, _)).WillOnce(Return(true));
-        EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _, _, _))
+        EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, _))
             .WillOnce(Return(ByMove(std::move(m_mediaPipelineMock))));
         EXPECT_TRUE(secondSut.attachMediaPlayerClient(&m_object, kMaxVideoWidth, kMaxVideoHeight));
         EXPECT_TRUE(secondSut.hasControl());

--- a/tests/ut/RialtoGstTest.cpp
+++ b/tests/ut/RialtoGstTest.cpp
@@ -287,7 +287,7 @@ void RialtoGstTest::setPausedState(GstElement *pipeline, RialtoMSEBaseSink *sink
     const std::string kUrl{"mse://1"};
     EXPECT_CALL(m_mediaPipelineMock, load(kMediaType, kMimeType, kUrl)).WillOnce(Return(true));
     EXPECT_CALL(m_mediaPipelineMock, pause()).WillOnce(Return(true));
-    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements, _, _))
+    EXPECT_CALL(*m_mediaPipelineFactoryMock, createMediaPipeline(_, kDefaultRequirements))
         .WillOnce(Return(ByMove(std::move(m_mediaPipeline))));
     EXPECT_EQ(GST_STATE_CHANGE_ASYNC, gst_element_set_state(pipeline, GST_STATE_PAUSED));
 }

--- a/tests/ut/WebAudioClientBackendTests.cpp
+++ b/tests/ut/WebAudioClientBackendTests.cpp
@@ -72,8 +72,7 @@ public:
 
 TEST_F(WebAudioClientBackendTests, ShouldFailToCreateBackend)
 {
-    EXPECT_CALL(*m_playerFactoryMock,
-                createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config)))
+    EXPECT_CALL(*m_playerFactoryMock, createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config)))
         .WillOnce(Return(nullptr));
     EXPECT_FALSE(m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, m_config));
 }

--- a/tests/ut/WebAudioClientBackendTests.cpp
+++ b/tests/ut/WebAudioClientBackendTests.cpp
@@ -64,7 +64,7 @@ public:
     bool createBackend()
     {
         EXPECT_CALL(*m_playerFactoryMock,
-                    createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config), _, _))
+                    createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config)))
             .WillOnce(Return(ByMove(std::move(m_playerMock))));
         return m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, m_config);
     }
@@ -73,7 +73,7 @@ public:
 TEST_F(WebAudioClientBackendTests, ShouldFailToCreateBackend)
 {
     EXPECT_CALL(*m_playerFactoryMock,
-                createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config), _, _))
+                createWebAudioPlayer(_, kAudioMimeType, kPriority, webAudioConfigMatcher(m_config)))
         .WillOnce(Return(nullptr));
     EXPECT_FALSE(m_sut.createWebAudioBackend(m_clientMock, kAudioMimeType, kPriority, m_config));
 }


### PR DESCRIPTION
Summary: Removing the methods from public interface that allows for mock injection.
Type: Cleanup
Test Plan: Unittests.
Jira: NO-JIRA