### PR TITLE
Fix for NPLB tests failures

### DIFF
--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -366,7 +366,9 @@ static void rialto_mse_base_sink_flush_start(RialtoMSEBaseSink *sink)
 static void rialto_mse_base_sink_flush_stop(RialtoMSEBaseSink *sink, bool resetTime)
 {
     GST_INFO_OBJECT(sink, "Stopping flushing");
-    rialto_mse_base_sink_lost_state(sink);
+    // rialto_mse_base_sink_lost_state should be called here.
+    // It is temporarily disabled (until seek refactoring is finished).
+    // It causes some problems, when called twice, during seek and flush
     rialto_mse_base_sink_flush_server(sink, resetTime);
     std::lock_guard<std::mutex> lock(sink->priv->m_sinkMutex);
     sink->priv->m_isFlushOngoing = false;


### PR DESCRIPTION
Summary: Fix for NPLB tests failures
                 Temporarily disable rialto_mse_base_sink_lost_state, until seek refactoring is finished
                 rialto_mse_base_sink_lost_state cannot be called twice, during seek and flush
Type: Fix
Test Plan: Unittests, Component Tests, YT Conformance Tests
Jira: RIALTO-264