### PR TITLE
Print official release tag or git hash in rialto logs - rialto gstreamer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,6 @@ endif()
 add_compile_definitions(SRCREV="${SRCREV}")
 add_compile_definitions(TAGS="${TAGS}")
 
-message("Tags: ${TAGS}")
-message("SRCREV: ${SRCREV}")
-
 # Preprocesser Variable
 add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,33 @@ execute_process(
     COMMAND git rev-parse HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
     RESULT_VARIABLE RESULT 
-    OUTPUT_VARIABLE COMMIT_ID 
+    OUTPUT_VARIABLE SRCREV 
     OUTPUT_STRIP_TRAILING_WHITESPACE 
 )
 
 if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
 endif()
+
+# Retrieve release tag
+execute_process(
+    COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
+    OUTPUT_VARIABLE TAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE 
+)
+string(REPLACE "\n" ", " TAGS "${TAGS}")
+
+if(NOT TAGS STREQUAL "")
+    set(TAGS ${TAGS})
+endif() 
+
+# Preprocesser Variable
+add_compile_definitions(SRCREV="${SRCREV}")
+add_compile_definitions(TAGS="${TAGS}")
+
+message("Tags: ${TAGS}")
+message("SRCREV: ${SRCREV}")
 
 # Preprocesser Variable
 add_compile_definitions(COMMIT_ID="${COMMIT_ID}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(RESULT)
     message("Failed to get git commit ID: ${RESULT}")
 endif()
 
-# Retrieve release tag
+# Retrieve release tag(s)
 execute_process(
     COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  

--- a/source/RialtoGSteamerPlugin.cpp
+++ b/source/RialtoGSteamerPlugin.cpp
@@ -26,8 +26,6 @@
 static gboolean rialto_mse_sinks_init(GstPlugin *plugin)
 {
     init_gst_debug_category();
-    // const char commitID[] = COMMIT_ID;
-    // GST_INFO("Commit ID: %s", (std::strlen(commitID) > 0) ? commitID : "unknown");
 
     const char kSrcRev[] = SRCREV;
     const char kTags[] = TAGS;

--- a/source/RialtoGSteamerPlugin.cpp
+++ b/source/RialtoGSteamerPlugin.cpp
@@ -26,8 +26,27 @@
 static gboolean rialto_mse_sinks_init(GstPlugin *plugin)
 {
     init_gst_debug_category();
-    const char commitID[] = COMMIT_ID;
-    GST_INFO("Commit ID: %s", (std::strlen(commitID) > 0) ? commitID : "unknown");
+    // const char commitID[] = COMMIT_ID;
+    // GST_INFO("Commit ID: %s", (std::strlen(commitID) > 0) ? commitID : "unknown");
+
+    const char kSrcRev[] = SRCREV;
+    const char kTags[] = TAGS;
+
+    if (std::strlen(kSrcRev) > 0)
+    {
+        if (std::strlen(kTags) > 0)
+        {
+            GST_INFO("Release Tag(s): %s (Commit ID: %s)", kTags, kSrcRev);
+        }
+        else
+        {
+            GST_INFO("Release Tag(s): No Release Tags! (Commit ID: %s)", kSrcRev);
+        }
+    }
+    else
+    {
+        GST_WARNING("Failed to get git commit ID!");
+    }
 
     const char *socketPathStr = getenv("RIALTO_SOCKET_PATH");
     guint sinkRank = socketPathStr ? std::numeric_limits<int>::max() : 0;


### PR DESCRIPTION
Summary: Printing release tag or git hash in rialto logs -  rialto gstreamer
Type: Fix
Test Plan: Unit tests and Full Stack
Jira: RIALTO-518