### PR TITLE
Fix for a spurious error message appearing in the log

### DIFF
--- a/source/MediaPlayerManager.cpp
+++ b/source/MediaPlayerManager.cpp
@@ -107,9 +107,9 @@ void MediaPlayerManager::releaseMediaPlayerClient()
                 auto client = it->second.client;
                 client->stop();
 
-                // destroyClientBackend() unsubscribes from messages, call this before
+                // destroyClientBackend() unsubscribes from messages. Call this before
                 // calling stopStreaming() otherwise received messages can't be sent
-                // and an ERROR might be generated
+                // and this results in an ERROR message in the log
                 client->destroyClientBackend();
 
                 client->stopStreaming();

--- a/source/MediaPlayerManager.cpp
+++ b/source/MediaPlayerManager.cpp
@@ -104,9 +104,15 @@ void MediaPlayerManager::releaseMediaPlayerClient()
             it->second.refCount--;
             if (it->second.refCount == 0)
             {
-                it->second.client->stop();
-                it->second.client->stopStreaming();
-                it->second.client->destroyClientBackend();
+                auto client = it->second.client;
+                client->stop();
+
+                // destroyClientBackend() unsubscribes from messages, call this before
+                // calling stopStreaming() otherwise received messages can't be sent
+                // and an ERROR might be generated
+                client->destroyClientBackend();
+
+                client->stopStreaming();
                 m_mediaPlayerClientsInfo.erase(it);
             }
             else


### PR DESCRIPTION
Summary: An error message could appear in the log when releaseMediaPlayerClient called
Type: Fix  
Test Plan: UT
Jira: NO-JIRA