### PR TITLE
Add STREAM_COLLECTION event handling to fix single source playback with Playbin3

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -260,6 +260,7 @@ public:
     void removeSource(int32_t sourceId);
     void handlePlaybackStateChange(firebolt::rialto::PlaybackState state);
     void handleSourceFlushed(int32_t sourceId);
+    void sendAllSourcesAttachedIfPossible();
 
     void setVideoRectangle(const std::string &rectangleString);
     std::string getVideoRectangle();
@@ -277,9 +278,11 @@ public:
     bool getMute();
     void setAudioStreamsInfo(int32_t audioStreams, bool isAudioOnly);
     void setVideoStreamsInfo(int32_t videoStreams, bool isVideoOnly);
+    void handleStreamCollection(int32_t audioStreams, int32_t videoStreams);
 
 private:
     bool areAllStreamsAttached();
+    void sendAllSourcesAttachedIfPossibleInternal();
 
     std::unique_ptr<IMessageQueue> m_backendQueue;
     std::shared_ptr<IMessageQueueFactory> m_messageQueueFactory;

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -781,6 +781,35 @@ bool rialto_mse_base_sink_event(GstPad *pad, GstObject *parent, GstEvent *event)
         rialto_mse_base_sink_flush_stop(sink, reset_time);
         break;
     }
+    case GST_EVENT_STREAM_COLLECTION:
+    {
+        std::shared_ptr<GStreamerMSEMediaPlayerClient> client = sink->priv->m_mediaPlayerManager.getMediaPlayerClient();
+        if (!client)
+        {
+            return FALSE;
+        }
+        int32_t videoStreams{0}, audioStreams{0};
+        GstStreamCollection *streamCollection;
+        gst_event_parse_stream_collection(event, &streamCollection);
+        guint streamsSize = gst_stream_collection_get_size(streamCollection);
+        for (guint i = 0; i < streamsSize; ++i)
+        {
+            auto *stream = gst_stream_collection_get_stream(streamCollection, i);
+            auto type = gst_stream_get_stream_type(stream);
+            if (type & GST_STREAM_TYPE_AUDIO)
+            {
+                ++audioStreams;
+            }
+            else if (type & GST_STREAM_TYPE_VIDEO)
+            {
+                ++videoStreams;
+            }
+        }
+        gst_object_unref(streamCollection);
+        client->handleStreamCollection(audioStreams, videoStreams);
+        client->sendAllSourcesAttachedIfPossible();
+        break;
+    }
     default:
         break;
     }

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -786,6 +786,7 @@ bool rialto_mse_base_sink_event(GstPad *pad, GstObject *parent, GstEvent *event)
         std::shared_ptr<GStreamerMSEMediaPlayerClient> client = sink->priv->m_mediaPlayerManager.getMediaPlayerClient();
         if (!client)
         {
+            gst_event_unref(event);
             return FALSE;
         }
         int32_t videoStreams{0}, audioStreams{0};

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -1085,3 +1085,35 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldPostGenericError)
     gst_message_unref(receivedMessage);
     gst_object_unref(pipeline);
 }
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldFailToHandleStreamCollectionEvent)
+{
+    GstStreamCollection *streamCollection{gst_stream_collection_new("test_stream")};
+
+    RialtoMSEBaseSink *audioSink{createAudioSink()};
+
+    EXPECT_FALSE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                            gst_event_new_stream_collection(streamCollection)));
+    gst_object_unref(audioSink);
+    gst_object_unref(streamCollection);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldHandleStreamCollectionEvent)
+{
+    GstStreamCollection *streamCollection{gst_stream_collection_new("test_stream")};
+    gst_stream_collection_add_stream(streamCollection,
+                                     gst_stream_new("s_audio", nullptr, GST_STREAM_TYPE_AUDIO, GST_STREAM_FLAG_NONE));
+    gst_stream_collection_add_stream(streamCollection,
+                                     gst_stream_new("s_video", nullptr, GST_STREAM_TYPE_VIDEO, GST_STREAM_FLAG_NONE));
+
+    RialtoMSEBaseSink *audioSink{createAudioSink()};
+    GstElement *pipeline{createPipelineWithSink(audioSink)};
+
+    setPausedState(pipeline, audioSink);
+
+    EXPECT_TRUE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                           gst_event_new_stream_collection(streamCollection)));
+    setNullState(pipeline, kUnknownSourceId);
+    gst_object_unref(pipeline);
+    gst_object_unref(streamCollection);
+}

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -910,3 +910,32 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldAttachAllSources)
     gst_object_unref(audioSink);
     gst_object_unref(videoSink);
 }
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSendAllSourcesAttached)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    expectPostMessage();
+    m_sut->sendAllSourcesAttachedIfPossible();
+
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSendAllSourcesAttached)
+{
+    constexpr int kAudioStreams{1}, kVideoStreams{0};
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    expectPostMessage();
+    m_sut->handleStreamCollection(kAudioStreams, kVideoStreams);
+
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, allSourcesAttached()).WillOnce(Return(true));
+    expectPostMessage();
+    m_sut->sendAllSourcesAttachedIfPossible();
+
+    gst_object_unref(audioSink);
+}


### PR DESCRIPTION
Summary: Add STREAM_COLLECTION event handling to fix single source playback with Playbin3
Type: Fix
Test Plan: UnitTests, ComponentTests, YT Conformance Tests
Jira: RIALTO-559