### PR TITLE
Register and unregister clients with proxy to fix data race, and tidy the surrounding code

### DIFF
--- a/source/ControlBackend.h
+++ b/source/ControlBackend.h
@@ -56,7 +56,7 @@ public:
                 GST_ERROR("Unable to create control");
                 return;
             }
-            if (!m_control->registerClient(m_controlClient, m_rialtoClientState))
+            if (!m_control->registerClientAndUnregisterOnDestruction(m_controlClient, m_rialtoClientState))
             {
                 GST_ERROR("Unable to register client");
                 return;

--- a/tests/mocks/ControlMock.h
+++ b/tests/mocks/ControlMock.h
@@ -34,7 +34,8 @@ public:
 class ControlMock : public IControl
 {
 public:
-    MOCK_METHOD(bool, registerClient, (std::weak_ptr<IControlClient> client, ApplicationState &appState), (override));
+    MOCK_METHOD(bool, registerClientAndUnregisterOnDestruction,
+                (std::weak_ptr<IControlClient> client, ApplicationState &appState), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/ut/ControlBackendTests.cpp
+++ b/tests/ut/ControlBackendTests.cpp
@@ -54,14 +54,14 @@ TEST_F(ControlBackendTests, ShouldFailToStartWhenControlIsNull)
 TEST_F(ControlBackendTests, ShouldFailToStartWhenRegisterClientFails)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _)).WillOnce(Return(false));
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _)).WillOnce(Return(false));
     m_sut = std::make_unique<ControlBackend>();
 }
 
 TEST_F(ControlBackendTests, ShouldSkipWaitingForRunningWhenRunningStateWasSetDuringInitialisation)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::RUNNING), Return(true)));
     m_sut = std::make_unique<ControlBackend>();
     EXPECT_TRUE(m_sut->waitForRunning());
@@ -71,7 +71,7 @@ TEST_F(ControlBackendTests, ShouldSkipWaitingForRunningWhenRunningStateWasSetEar
 {
     std::weak_ptr<IControlClient> weakClient;
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SaveArg<0>(&weakClient), SetArgReferee<1>(ApplicationState::INACTIVE), Return(true)));
     m_sut = std::make_unique<ControlBackend>();
     auto client = weakClient.lock();
@@ -83,7 +83,7 @@ TEST_F(ControlBackendTests, ShouldSkipWaitingForRunningWhenRunningStateWasSetEar
 TEST_F(ControlBackendTests, ShouldFailToWaitForRunning)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::INACTIVE), Return(true)));
     m_sut = std::make_unique<ControlBackend>();
     EXPECT_FALSE(m_sut->waitForRunning());
@@ -92,7 +92,7 @@ TEST_F(ControlBackendTests, ShouldFailToWaitForRunning)
 TEST_F(ControlBackendTests, ShouldRemoveControlBackend)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::RUNNING), Return(true)));
     m_sut = std::make_unique<ControlBackend>();
     m_sut->removeControlBackend();

--- a/tests/ut/GstreamerWebAudioSinkTests.cpp
+++ b/tests/ut/GstreamerWebAudioSinkTests.cpp
@@ -101,7 +101,7 @@ TEST_F(GstreamerWebAudioSinkTests, ShouldCreateSink)
 TEST_F(GstreamerWebAudioSinkTests, ShouldNotReachReadyStateWhenAppStateIsInactive)
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(firebolt::rialto::ApplicationState::INACTIVE), Return(true)));
     GstElement *sink = gst_element_factory_make("rialtowebaudiosink", "rialtowebaudiosink");
     GstElement *pipeline = createPipelineWithSink(RIALTO_WEB_AUDIO_SINK(sink));

--- a/tests/ut/RialtoGstTest.cpp
+++ b/tests/ut/RialtoGstTest.cpp
@@ -182,7 +182,7 @@ GstCaps *RialtoGstTest::createVideoCaps() const
 RialtoMSEBaseSink *RialtoGstTest::createAudioSink() const
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::RUNNING), Return(true)));
     GstElement *audioSink = gst_element_factory_make("rialtomseaudiosink", "rialtomseaudiosink");
     return RIALTO_MSE_BASE_SINK(audioSink);
@@ -191,7 +191,7 @@ RialtoMSEBaseSink *RialtoGstTest::createAudioSink() const
 RialtoMSEBaseSink *RialtoGstTest::createVideoSink() const
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::RUNNING), Return(true)));
     GstElement *videoSink = gst_element_factory_make("rialtomsevideosink", "rialtomsevideosink");
     return RIALTO_MSE_BASE_SINK(videoSink);
@@ -200,7 +200,7 @@ RialtoMSEBaseSink *RialtoGstTest::createVideoSink() const
 RialtoWebAudioSink *RialtoGstTest::createWebAudioSink() const
 {
     EXPECT_CALL(*m_controlFactoryMock, createControl()).WillOnce(Return(m_controlMock));
-    EXPECT_CALL(*m_controlMock, registerClient(_, _))
+    EXPECT_CALL(*m_controlMock, registerClientAndUnregisterOnDestruction(_, _))
         .WillOnce(DoAll(SetArgReferee<1>(ApplicationState::RUNNING), Return(true)));
     GstElement *webAudioSink = gst_element_factory_make("rialtowebaudiosink", "rialtowebaudiosink");
     return RIALTO_WEB_AUDIO_SINK(webAudioSink);


### PR DESCRIPTION
Summary: register and unregister clients (of control) via a proxy (this prevents a data race and updates c style pointers to c++). The call to registerClient in ControlService::addControl was deceiving since this didn't actually register any client... it just called setApplicationState therefore changed to call setApplicationState() direct (and then "controlServerInternal" doesn't need a "registerClient" method). Also the control method registerClient() is renamed to registerClientAndUnregisterOnDestruction() which is a more complete description of what it does
Type: Fix
Test Plan: UT/CT and test webaudio on XiOne US box
Jira: NO-JIRA