### PR TITLE
Riato 582 get stats

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -181,6 +181,16 @@ int64_t GStreamerMSEMediaPlayerClient::getPosition(int32_t sourceId)
     return position;
 }
 
+bool GStreamerMSEMediaPlayerClient::getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames)
+{
+    if (!m_clientBackend)
+    {
+        return false;
+    }
+
+    return m_clientBackend->getStats(sourceId, renderedFrames, droppedFrames);
+}
+
 bool GStreamerMSEMediaPlayerClient::createBackend()
 {
     bool result = false;

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -263,6 +263,8 @@ public:
 
     void getPositionDo(int64_t *position, int32_t sourceId);
     int64_t getPosition(int32_t sourceId);
+    bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames);
+
     firebolt::rialto::AddSegmentStatus
     addSegment(unsigned int needDataRequestId,
                const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment);

--- a/source/MediaPlayerClientBackend.h
+++ b/source/MediaPlayerClientBackend.h
@@ -86,6 +86,11 @@ public:
 
     bool getPosition(int64_t &position) override { return m_mediaPlayerBackend->getPosition(position); }
 
+    bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames) override
+    {
+        return m_mediaPlayerBackend->getStats(sourceId, renderedFrames, droppedFrames);
+    }
+
     bool renderFrame() override { return m_mediaPlayerBackend->renderFrame(); }
 
     bool setVolume(double volume) override { return m_mediaPlayerBackend->setVolume(volume); }

--- a/source/MediaPlayerClientBackendInterface.h
+++ b/source/MediaPlayerClientBackendInterface.h
@@ -46,6 +46,7 @@ public:
     addSegment(unsigned int needDataRequestId,
                const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment) = 0;
     virtual bool getPosition(int64_t &position) = 0;
+    virtual bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames) = 0;
     virtual bool renderFrame() = 0;
     virtual bool setVolume(double volume) = 0;
     virtual bool getVolume(double &volume) = 0;

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -52,6 +52,7 @@ enum
     PROP_IS_SINGLE_PATH_STREAM,
     PROP_N_STREAMS,
     PROP_HAS_DRM,
+    PROP_STATS,
     PROP_LAST
 };
 
@@ -212,6 +213,30 @@ static void rialto_mse_base_sink_get_property(GObject *object, guint propId, GVa
     case PROP_HAS_DRM:
         g_value_set_boolean(value, sink->priv->m_hasDrm);
         break;
+    case PROP_STATS:
+    {
+        guint64 totalVideoFrames{5};
+        guint64 droppedVideoFrames{2};
+
+        std::shared_ptr<GStreamerMSEMediaPlayerClient> client = sink->priv->m_mediaPlayerManager.getMediaPlayerClient();
+        if (!client)
+        {
+            GST_ERROR_OBJECT(sink, "Could not get the media player client");
+            return;
+        }
+
+        if (client->getStats(sink->priv->m_sourceId, totalVideoFrames, droppedVideoFrames))
+        {
+            GstStructure *stats{gst_structure_new("stats", "rendered", G_TYPE_UINT64, totalVideoFrames, "dropped",
+                                                  G_TYPE_UINT64, droppedVideoFrames, nullptr)};
+            g_value_set_pointer(value, stats);
+        }
+        else
+        {
+            GST_ERROR_OBJECT(sink, "No stats returned from client");
+        }
+    }
+    break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, pspec);
         break;
@@ -631,6 +656,9 @@ static void rialto_mse_base_sink_class_init(RialtoMSEBaseSinkClass *klass)
     g_object_class_install_property(gobjectClass, PROP_HAS_DRM,
                                     g_param_spec_boolean("has-drm", "has drm", "has drm", TRUE,
                                                          GParamFlags(G_PARAM_READWRITE)));
+    g_object_class_install_property(gobjectClass, PROP_STATS,
+                                    g_param_spec_pointer("stats", NULL, "pointer to a gst_structure",
+                                                         GParamFlags(G_PARAM_READABLE)));
 }
 
 GstFlowReturn rialto_mse_base_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf)

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -360,9 +360,6 @@ static void rialto_mse_base_sink_get_property(GObject *object, guint propId, GVa
         break;
     case PROP_STATS:
     {
-        guint64 totalVideoFrames{5};
-        guint64 droppedVideoFrames{2};
-
         std::shared_ptr<GStreamerMSEMediaPlayerClient> client = sink->priv->m_mediaPlayerManager.getMediaPlayerClient();
         if (!client)
         {
@@ -370,6 +367,8 @@ static void rialto_mse_base_sink_get_property(GObject *object, guint propId, GVa
             return;
         }
 
+        guint64 totalVideoFrames;
+        guint64 droppedVideoFrames;
         if (client->getStats(sink->priv->m_sourceId, totalVideoFrames, droppedVideoFrames))
         {
             GstStructure *stats{gst_structure_new("stats", "rendered", G_TYPE_UINT64, totalVideoFrames, "dropped",

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -46,6 +46,8 @@ public:
     MOCK_METHOD(bool, setPlaybackRate, (double rate), (override));
     MOCK_METHOD(bool, setPosition, (int64_t position), (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
+    MOCK_METHOD(bool, getStats, (int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames), (override));
+
     MOCK_METHOD(bool, setVideoWindow, (uint32_t x, uint32_t y, uint32_t width, uint32_t height), (override));
     MOCK_METHOD(bool, haveData, (MediaSourceStatus status, uint32_t needDataRequestId), (override));
     MOCK_METHOD(AddSegmentStatus, addSegment,

--- a/tests/mocks/MediaPlayerClientBackendMock.h
+++ b/tests/mocks/MediaPlayerClientBackendMock.h
@@ -49,6 +49,7 @@ public:
                  const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment),
                 (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
+    MOCK_METHOD(bool, getStats, (int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
     MOCK_METHOD(bool, setVolume, (double volume), (override));
     MOCK_METHOD(bool, getVolume, (double &volume), (override));

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -197,6 +197,7 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldGetStatsProperty)
     g_object_get(audioSink, "stats", &stats, nullptr);
     EXPECT_NE(stats, nullptr);
 
+    gst_structure_free(stats);
     setNullState(pipeline, kSourceId);
     gst_caps_unref(caps);
     gst_object_unref(pipeline);

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -180,6 +180,28 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldGetHasDrmProperty)
     gst_object_unref(audioSink);
 }
 
+TEST_F(GstreamerMseBaseSinkTests, ShouldGetStatsProperty)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    EXPECT_CALL(m_mediaPipelineMock, getStats(_, _, _)).WillOnce(Return(true));
+    GstStructure *stats{nullptr};
+    g_object_get(audioSink, "stats", &stats, nullptr);
+    EXPECT_NE(stats, nullptr);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
 TEST_F(GstreamerMseBaseSinkTests, ShouldSetIsSinglePathStreamProperty)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -202,6 +202,18 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldGetStatsProperty)
     gst_object_unref(pipeline);
 }
 
+TEST_F(GstreamerMseBaseSinkTests, ShouldFailToGetStatsProperty)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+
+    // No pipeline therefore the stats should still be null
+    GstStructure *stats{nullptr};
+    g_object_get(audioSink, "stats", &stats, nullptr);
+    EXPECT_EQ(stats, nullptr);
+
+    gst_object_unref(audioSink);
+}
+
 TEST_F(GstreamerMseBaseSinkTests, ShouldSetIsSinglePathStreamProperty)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();


### PR DESCRIPTION
Summary: Get stats for the number of rendered and dropped frames
Type: Fix  
Test Plan: UT, CT, test that wpe-webkit can get stats on XiOne US
Jira: RIALTO-582
