### PR TITLE
Send play request if one source is AWAITING_PLAYING

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -234,7 +234,7 @@ StateChangeResult GStreamerMSEMediaPlayerClient::play(int32_t sourceId)
                 GST_INFO("Server is already playing");
                 sourceIt->second.m_state = ClientState::PLAYING;
 
-                if (checkIfAllAttachedSourcesInState(ClientState::PLAYING))
+                if (checkIfAllAttachedSourcesInStates({ClientState::PLAYING}))
                 {
                     m_clientState = ClientState::PLAYING;
                 }
@@ -293,7 +293,7 @@ StateChangeResult GStreamerMSEMediaPlayerClient::pause(int32_t sourceId)
                 GST_INFO("Server is already paused");
                 sourceIt->second.m_state = ClientState::PAUSED;
 
-                if (checkIfAllAttachedSourcesInState(ClientState::PAUSED))
+                if (checkIfAllAttachedSourcesInStates({ClientState::PAUSED}))
                 {
                     m_clientState = ClientState::PAUSED;
                 }
@@ -307,7 +307,7 @@ StateChangeResult GStreamerMSEMediaPlayerClient::pause(int32_t sourceId)
                 bool shouldPause = false;
                 if (m_clientState == ClientState::READY)
                 {
-                    if (checkIfAllAttachedSourcesInState(ClientState::AWAITING_PAUSED))
+                    if (checkIfAllAttachedSourcesInStates({ClientState::AWAITING_PAUSED}))
                     {
                         shouldPause = true;
                     }
@@ -498,7 +498,7 @@ void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossibleInternal()
 
         // In playbin3 streams, confirmation about number of available sources comes after attaching the source,
         // so we need to check if all sources are ready to pause
-        if (checkIfAllAttachedSourcesInState(ClientState::AWAITING_PAUSED))
+        if (checkIfAllAttachedSourcesInStates({ClientState::AWAITING_PAUSED}))
         {
             GST_INFO("Sending pause command, because all attached sources are ready to pause");
             m_clientBackend->pause();
@@ -751,16 +751,11 @@ void GStreamerMSEMediaPlayerClient::handleStreamCollection(int32_t audioStreams,
         });
 }
 
-bool GStreamerMSEMediaPlayerClient::checkIfAllAttachedSourcesInState(ClientState state)
+bool GStreamerMSEMediaPlayerClient::checkIfAllAttachedSourcesInStates(const std::vector<ClientState> &states)
 {
     return std::all_of(m_attachedSources.begin(), m_attachedSources.end(),
-                       [state](const auto &source) { return source.second.m_state == state; });
-}
-
-bool GStreamerMSEMediaPlayerClient::checkIfAllAttachedSourcesInStates(const std::vector<ClientState>& states)
-{
-    return std::all_of(m_attachedSources.begin(), m_attachedSources.end(),
-                       [states](const auto &source) { return std::find(states.begin(), states.end(), source.second.m_state) != states.end(); });
+                       [states](const auto &source)
+                       { return std::find(states.begin(), states.end(), source.second.m_state) != states.end(); });
 }
 
 bool GStreamerMSEMediaPlayerClient::areAllStreamsAttached()

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -305,6 +305,7 @@ private:
     bool areAllStreamsAttached();
     void sendAllSourcesAttachedIfPossibleInternal();
     bool checkIfAllAttachedSourcesInState(ClientState state);
+    bool checkIfAllAttachedSourcesInStates(const std::vector<ClientState>& states);
 
     std::unique_ptr<IMessageQueue> m_backendQueue;
     std::shared_ptr<IMessageQueueFactory> m_messageQueueFactory;

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -304,8 +304,7 @@ public:
 private:
     bool areAllStreamsAttached();
     void sendAllSourcesAttachedIfPossibleInternal();
-    bool checkIfAllAttachedSourcesInState(ClientState state);
-    bool checkIfAllAttachedSourcesInStates(const std::vector<ClientState>& states);
+    bool checkIfAllAttachedSourcesInStates(const std::vector<ClientState> &states);
 
     std::unique_ptr<IMessageQueue> m_backendQueue;
     std::shared_ptr<IMessageQueueFactory> m_messageQueueFactory;

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -771,6 +771,32 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldDoNothingWhenLostStateNotAttach
     EXPECT_EQ(m_sut->getClientState(), ClientState::IDLE);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSendPlayWhenRecoveringFromLostStateFromPlaying)
+{
+    attachAudioVideo();
+    allSourcesWantToPause();
+    serverTransitionedToPaused();
+    allSourcesWantToPlay();
+    serverTransitionedToPlaying();
+
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, pause()).WillOnce(Return(true));
+    m_sut->notifyLostState(m_audioSourceId);
+    EXPECT_EQ(m_sut->getClientState(), ClientState::AWAITING_PAUSED);
+
+    serverTransitionedToPaused();
+    EXPECT_EQ(m_sut->getClientState(), ClientState::PAUSED);
+
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, play()).WillOnce(Return(true));
+    m_sut->play(m_audioSourceId);
+    EXPECT_EQ(m_sut->getClientState(), ClientState::AWAITING_PLAYING);
+
+    serverTransitionedToPlaying();
+    EXPECT_EQ(m_sut->getClientState(), ClientState::PLAYING);
+
+    gst_object_unref(m_audioSink);
+    gst_object_unref(m_videoSink);
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotPlayWhenNotAllAttachedPlaying)
 {
     attachAudioVideo();


### PR DESCRIPTION
Summary: During audio switching, rialto-gstreamer gets stuck in the paused state when moving to playing. rialto-gstreamer should not have to wait for he vdeo sink to transition it AWAITING_PLAYING, as it is already PLAYING.
Type: Fix
Test Plan: Unittests, NTS Netflix tests
Jira: RIALTO-622