### PR TITLE
Require Audio Easing support on RialtoMSEAudioSink for Netflix - interface

### DIFF
--- a/source/Constants.h
+++ b/source/Constants.h
@@ -17,6 +17,9 @@
  */
 
 #pragma once
+#include <MediaCommon.h>
 
 constexpr double kDefaultVolume{1.0};
+constexpr uint32_t kDefaultVolumeDuration{0};
+constexpr firebolt::rialto::EaseType kDefaultEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kDefaultMute{false};

--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -672,9 +672,10 @@ bool GStreamerMSEMediaPlayerClient::renderFrame(RialtoMSEBaseSink *sink)
     return result;
 }
 
-void GStreamerMSEMediaPlayerClient::setVolume(double volume)
+void GStreamerMSEMediaPlayerClient::setVolume(double targetVolume, uint32_t volumeDuration,
+                                              firebolt::rialto::EaseType easeType)
 {
-    m_backendQueue->callInEventLoop([&]() { m_clientBackend->setVolume(volume); });
+    m_backendQueue->callInEventLoop([&]() { m_clientBackend->setVolume(targetVolume, volumeDuration, easeType); });
 }
 
 double GStreamerMSEMediaPlayerClient::getVolume()

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -294,7 +294,7 @@ public:
     void stopStreaming();
     void destroyClientBackend();
     bool renderFrame(RialtoMSEBaseSink *sink);
-    void setVolume(double volume);
+    void setVolume(double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType easeType);
     double getVolume();
     void setMute(bool mute);
     bool getMute();

--- a/source/MediaPlayerClientBackend.h
+++ b/source/MediaPlayerClientBackend.h
@@ -88,9 +88,12 @@ public:
 
     bool renderFrame() override { return m_mediaPlayerBackend->renderFrame(); }
 
-    bool setVolume(double volume) override { return m_mediaPlayerBackend->setVolume(volume); }
+    bool setVolume(double targetVolume, uint32_t volumeDuration, EaseType easeType) override
+    {
+        return m_mediaPlayerBackend->setVolume(targetVolume, volumeDuration, easeType);
+    }
 
-    bool getVolume(double &volume) override { return m_mediaPlayerBackend->getVolume(volume); }
+    bool getVolume(double &currentVolume) override { return m_mediaPlayerBackend->getVolume(currentVolume); }
 
     bool setMute(bool mute) override { return m_mediaPlayerBackend->setMute(mute); }
 

--- a/source/MediaPlayerClientBackendInterface.h
+++ b/source/MediaPlayerClientBackendInterface.h
@@ -47,8 +47,8 @@ public:
                const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment) = 0;
     virtual bool getPosition(int64_t &position) = 0;
     virtual bool renderFrame() = 0;
-    virtual bool setVolume(double volume) = 0;
-    virtual bool getVolume(double &volume) = 0;
+    virtual bool setVolume(double targetVolume, uint32_t volumeDuration, EaseType easeType) = 0;
+    virtual bool getVolume(double &currentVolume) = 0;
     virtual bool setMute(bool mute) = 0;
     virtual bool getMute(bool &mute) = 0;
     virtual bool flush(int32_t sourceId, bool resetTime) = 0;

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -72,7 +72,7 @@ static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *eleme
         }
         if (priv->isVolumeQueued)
         {
-            client->setVolume(priv->volume);
+            client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
             priv->isVolumeQueued = false;
         }
         if (priv->isMuteQueued)
@@ -283,7 +283,7 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_double(value, priv->volume);
+            g_value_set_double(value, priv->targetVolume);
             return;
         }
         g_value_set_double(value, client->getVolume());
@@ -329,14 +329,14 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     {
     case PROP_VOLUME:
     {
-        priv->volume = g_value_get_double(value);
+        priv->targetVolume = g_value_get_double(value);
         if (!client)
         {
             GST_DEBUG_OBJECT(object, "Enqueue volume setting");
             priv->isVolumeQueued = true;
             return;
         }
-        client->setVolume(priv->volume);
+        client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
         break;
     }
     case PROP_MUTE:

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -26,7 +26,9 @@ G_BEGIN_DECLS
 
 struct _RialtoMSEAudioSinkPrivate
 {
-    std::atomic<double> volume = kDefaultVolume;
+    std::atomic<double> targetVolume = kDefaultVolume;
+    std::atomic<uint32_t> volumeDuration = kDefaultVolumeDuration;
+    std::atomic<firebolt::rialto::EaseType> easeType = kDefaultEaseType;
     std::atomic_bool mute = kDefaultMute;
     std::atomic_bool isVolumeQueued = false;
     std::atomic_bool isMuteQueued = false;

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,8 +51,8 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double volume), (override));
-    MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
+    MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));
     MOCK_METHOD(bool, flush, (int32_t sourceId, bool resetTime), (override));

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,7 +51,7 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type), (override));
     MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,7 +51,7 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
     MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));

--- a/tests/mocks/MediaPlayerClientBackendMock.h
+++ b/tests/mocks/MediaPlayerClientBackendMock.h
@@ -50,8 +50,9 @@ public:
                 (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double volume), (override));
-    MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type),
+                (override));
+    MOCK_METHOD(bool, getVolume, (double &curretVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));
     MOCK_METHOD(bool, flush, (int32_t sourceId, bool resetTime), (override));

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -347,7 +347,10 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldSetVolume)
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     constexpr gdouble kVolume{0.8};
-    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    constexpr uint32_t kVolumeDuration{0};
+    constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
+
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     g_object_set(textContext.m_sink, "volume", kVolume, nullptr);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
@@ -360,9 +363,12 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldSetCachedVolume)
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
     constexpr gdouble kVolume{0.8};
+    constexpr uint32_t kVolumeDuration{0};
+    constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
+
     g_object_set(audioSink, "volume", kVolume, nullptr);
 
-    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     load(pipeline);
     EXPECT_EQ(GST_STATE_CHANGE_ASYNC, gst_element_set_state(pipeline, GST_STATE_PAUSED));
 

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -48,6 +48,8 @@ const std::string kUrl{"mse://1"};
 constexpr firebolt::rialto::MediaType kMediaType{firebolt::rialto::MediaType::MSE};
 const std::string kMimeType{""};
 constexpr double kVolume{1.0};
+constexpr uint32_t kVolumeDuration{30};
+constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kMute{true};
 constexpr bool kResetTime{true};
 constexpr uint32_t kDuration{30};
@@ -1106,8 +1108,8 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldRenderFrame)
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetVolume)
 {
     expectCallInEventLoop();
-    EXPECT_CALL(*m_mediaPlayerClientBackendMock, setVolume(kVolume)).WillOnce(Return(true));
-    m_sut->setVolume(kVolume);
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
+    m_sut->setVolume(kVolume, kVolumeDuration, kEaseType);
 }
 
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetVolume)

--- a/tests/ut/MediaPlayerClientBackendTests.cpp
+++ b/tests/ut/MediaPlayerClientBackendTests.cpp
@@ -39,6 +39,8 @@ namespace
 {
 constexpr VideoRequirements kVideoRequirements{1024, 768};
 constexpr double kVolume{0.7};
+constexpr uint32_t kVolumeDuration{1000};
+constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kMute{true};
 MATCHER_P(PtrMatcher, ptr, "")
 {
@@ -219,10 +221,10 @@ TEST_F(MediaPlayerClientBackendTests, ShouldRenderFrame)
 
 TEST_F(MediaPlayerClientBackendTests, ShouldSetVolume)
 {
-    EXPECT_CALL(*m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    EXPECT_CALL(*m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     initializeMediaPipeline();
     ASSERT_TRUE(m_sut.isMediaPlayerBackendCreated());
-    EXPECT_TRUE(m_sut.setVolume(kVolume));
+    EXPECT_TRUE(m_sut.setVolume(kVolume, kVolumeDuration, kEaseType));
 }
 
 TEST_F(MediaPlayerClientBackendTests, ShouldGetVolume)


### PR DESCRIPTION
Summary: Require Audio Easing support on RialtoMSEAudioSink for Netflix - interface changes
Type: Feature
Test Plan: UT
Jira: RIALTO-593