### PR TITLE
Cache the immediate-output property until the pipeline is created

### DIFF
--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -66,6 +66,7 @@ void rialto_mse_base_handle_rialto_server_completed_flush(RialtoMSEBaseSink *sin
 void rialto_mse_base_handle_rialto_server_sent_qos(RialtoMSEBaseSink *sink, uint64_t processed, uint64_t dropped);
 void rialto_mse_base_handle_rialto_server_error(RialtoMSEBaseSink *sink, firebolt::rialto::PlaybackError error);
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
+void rialto_mse_base_handle_source_id_assigned(RialtoMSEBaseSink *sink);
 
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 GstFlowReturn rialto_mse_base_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf);

--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -66,7 +66,6 @@ void rialto_mse_base_handle_rialto_server_completed_flush(RialtoMSEBaseSink *sin
 void rialto_mse_base_handle_rialto_server_sent_qos(RialtoMSEBaseSink *sink, uint64_t processed, uint64_t dropped);
 void rialto_mse_base_handle_rialto_server_error(RialtoMSEBaseSink *sink, firebolt::rialto::PlaybackError error);
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
-void rialto_mse_base_handle_source_id_assigned(RialtoMSEBaseSink *sink);
 
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 GstFlowReturn rialto_mse_base_sink_chain(GstPad *pad, GstObject *parent, GstBuffer *buf);

--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -77,12 +77,12 @@ static GstStateChangeReturn rialto_mse_video_sink_change_state(GstElement *eleme
             return GST_STATE_CHANGE_FAILURE;
         }
 
-        std::unique_lock lock{priv->rectangleMutex};
+        std::unique_lock lock{priv->propertyMutex};
         if (priv->rectangleSettingQueued)
         {
             GST_DEBUG_OBJECT(sink, "Set queued video rectangle");
-            client->setVideoRectangle(priv->videoRectangle);
             priv->rectangleSettingQueued = false;
+            client->setVideoRectangle(priv->videoRectangle);
         }
         break;
     }
@@ -158,8 +158,8 @@ rialto_mse_video_sink_create_media_source(RialtoMSEBaseSink *sink, GstCaps *caps
 
 static gboolean rialto_mse_video_sink_event(GstPad *pad, GstObject *parent, GstEvent *event)
 {
-    RialtoMSEBaseSink *sink = RIALTO_MSE_BASE_SINK(parent);
-    RialtoMSEBaseSinkPrivate *basePriv = sink->priv;
+    RialtoMSEBaseSink *baseSink = RIALTO_MSE_BASE_SINK(parent);
+    RialtoMSEBaseSinkPrivate *basePriv = baseSink->priv;
     switch (GST_EVENT_TYPE(event))
     {
     case GST_EVENT_CAPS:
@@ -168,36 +168,47 @@ static gboolean rialto_mse_video_sink_event(GstPad *pad, GstObject *parent, GstE
         gst_event_parse_caps(event, &caps);
         if (basePriv->m_sourceAttached)
         {
-            GST_INFO_OBJECT(sink, "Source already attached. Skip calling attachSource");
+            GST_INFO_OBJECT(baseSink, "Source already attached. Skip calling attachSource");
             break;
         }
 
-        GST_INFO_OBJECT(sink, "Attaching VIDEO source with caps %" GST_PTR_FORMAT, caps);
+        GST_INFO_OBJECT(baseSink, "Attaching VIDEO source with caps %" GST_PTR_FORMAT, caps);
 
         std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> vsource =
-            rialto_mse_video_sink_create_media_source(sink, caps);
+            rialto_mse_video_sink_create_media_source(baseSink, caps);
         if (vsource)
         {
-            std::shared_ptr<GStreamerMSEMediaPlayerClient> client =
-                sink->priv->m_mediaPlayerManager.getMediaPlayerClient();
-            if ((!client) || (!client->attachSource(vsource, sink)))
+            std::shared_ptr<GStreamerMSEMediaPlayerClient> client = basePriv->m_mediaPlayerManager.getMediaPlayerClient();
+            if ((!client) || (!client->attachSource(vsource, baseSink)))
             {
-                GST_ERROR_OBJECT(sink, "Failed to attach VIDEO source");
+                GST_ERROR_OBJECT(baseSink, "Failed to attach VIDEO source");
             }
             else
             {
                 basePriv->m_sourceAttached = true;
 
                 // check if READY -> PAUSED was requested before source was attached
-                if (GST_STATE_NEXT(sink) == GST_STATE_PAUSED)
+                if (GST_STATE_NEXT(baseSink) == GST_STATE_PAUSED)
                 {
-                    client->pause(sink->priv->m_sourceId);
+                    client->pause(basePriv->m_sourceId);
+                }
+                RialtoMSEVideoSink *sink = RIALTO_MSE_VIDEO_SINK(parent);
+                RialtoMSEVideoSinkPrivate *priv = sink->priv;
+                std::unique_lock lock{priv->propertyMutex};
+                if (priv->immediateOutputQueued)
+                {
+                    GST_DEBUG_OBJECT(sink, "Set queued immediate-output");
+                    priv->immediateOutputQueued = false;
+                    if (!client->setImmediateOutput(basePriv->m_sourceId, priv->immediateOutput))
+                    {
+                        GST_ERROR_OBJECT(sink, "Could not set immediate-output");
+                    }
                 }
             }
         }
         else
         {
-            GST_ERROR_OBJECT(sink, "Failed to create VIDEO source");
+            GST_ERROR_OBJECT(baseSink, "Failed to create VIDEO source");
         }
 
         break;
@@ -232,10 +243,22 @@ static void rialto_mse_video_sink_get_property(GObject *object, guint propId, GV
     case PROP_WINDOW_SET:
         if (!client)
         {
-            std::unique_lock lock{priv->rectangleMutex};
-            g_value_set_string(value, priv->videoRectangle.c_str());
+            // It is possible that within rialto_mse_video_sink_change_state() that:-
+            //   1. the client could be created
+            //   AND 2. the lock on priv->propertyMutex is acquired
+            // therefore we need to re-check the client AFTER getting a lock ourselves...
+            std::unique_lock lock{priv->propertyMutex};
+            client = basePriv->m_mediaPlayerManager.getMediaPlayerClient();
+            if (!client)
+            {
+                // It's possible that someone calls to get this value before setting it, therefore
+                // queue a setting event for our default value so that it will become true when
+                // the client connects...
+                priv->rectangleSettingQueued = true;
+                g_value_set_string(value, priv->videoRectangle.c_str());
+            }
         }
-        else
+        if (client)
         {
             g_value_set_string(value, client->getVideoRectangle().c_str());
         }
@@ -263,18 +286,32 @@ static void rialto_mse_video_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            GST_ERROR_OBJECT(sink, "Could not get the media player client");
-            return;
+            // It is possible that within rialto_mse_video_sink_change_state() that:-
+            //   1. the client could be created
+            //   AND 2. the lock on priv->propertyMutex is acquired
+            // therefore we need to re-check the client AFTER getting a lock ourselves...
+            std::unique_lock lock{priv->propertyMutex};
+            client = basePriv->m_mediaPlayerManager.getMediaPlayerClient();
+            if (!client)
+            {
+                // It's possible that someone calls to get this value before setting it, therefore
+                // queue a setting event for our default value so that it will become true when
+                // the client connects...
+                priv->immediateOutputQueued = true;
+                g_value_set_boolean(value, priv->immediateOutput);
+            }
         }
-
-        bool immediateOutput{false};
-        if (!client->getImmediateOutput(sink->parent.priv->m_sourceId, immediateOutput))
+        if (client)
         {
-            GST_ERROR_OBJECT(sink, "Could not get immediate-output");
+            bool immediateOutput{priv->immediateOutput};
+            if (!client->getImmediateOutput(sink->parent.priv->m_sourceId, immediateOutput))
+            {
+                GST_ERROR_OBJECT(sink, "Could not get immediate-output");
+            }
+            g_value_set_boolean(value, immediateOutput);
         }
-        g_value_set_boolean(value, immediateOutput);
+        break;
     }
-    break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, pspec);
         break;
@@ -309,7 +346,7 @@ static void rialto_mse_video_sink_set_property(GObject *object, guint propId, co
             GST_WARNING_OBJECT(object, "Rectangle string not valid");
             break;
         }
-        std::unique_lock lock{priv->rectangleMutex};
+        std::unique_lock lock{priv->propertyMutex};
         priv->videoRectangle = std::string(rectangle);
         if (!client)
         {
@@ -343,15 +380,20 @@ static void rialto_mse_video_sink_set_property(GObject *object, guint propId, co
     }
     case PROP_IMMEDIATE_OUTPUT:
     {
+        bool immediateOutput = (g_value_get_boolean(value) != FALSE);
+        std::unique_lock lock{priv->propertyMutex};
+        priv->immediateOutput = immediateOutput;
         if (!client)
         {
-            GST_ERROR_OBJECT(sink, "Could not get the media player client");
-            return;
+            GST_ERROR_OBJECT(sink, "Immediate output setting enqueued");
+            priv->immediateOutputQueued = true;
         }
-
-        if (!client->setImmediateOutput(sink->parent.priv->m_sourceId, g_value_get_boolean(value) != FALSE))
+        else
         {
-            GST_ERROR_OBJECT(sink, "Could not set immediate-output");
+            if (!client->setImmediateOutput(basePriv->m_sourceId, immediateOutput))
+            {
+                GST_ERROR_OBJECT(sink, "Could not set immediate-output");
+            }
         }
         break;
     }

--- a/source/RialtoGStreamerMSEVideoSinkPrivate.h
+++ b/source/RialtoGStreamerMSEVideoSinkPrivate.h
@@ -29,9 +29,16 @@ struct _RialtoMSEVideoSinkPrivate
     uint32_t maxWidth = 0;
     uint32_t maxHeight = 0;
     bool stepOnPrerollEnabled = false;
-    std::mutex rectangleMutex;
+
+    std::mutex propertyMutex;
+    // START of variables locked by propertyMutex
+    // rectangle properties
     std::string videoRectangle = "0,0,1920,1080";
     bool rectangleSettingQueued = false;
+    // immediate output properties
+    bool immediateOutput{false};
+    bool immediateOutputQueued{false};
+    // END of variables locked by propertyMutex
 };
 
 G_END_DECLS

--- a/tests/ut/GstreamerMseVideoSinkTests.cpp
+++ b/tests/ut/GstreamerMseVideoSinkTests.cpp
@@ -120,6 +120,33 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldAttachSourceWithH264)
     gst_object_unref(pipeline);
 }
 
+TEST_F(GstreamerMseVideoSinkTests, ShouldSetQueuedImmediateOutput)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    {
+        // Queue an immediate-output request
+        EXPECT_CALL(m_mediaPipelineMock, setImmediateOutput(_, true)).WillOnce(Return(true));
+        RialtoMSEVideoSink *sink = RIALTO_MSE_VIDEO_SINK(videoSink);
+        sink->priv->immediateOutput = true;
+        sink->priv->immediateOutputQueued = true;
+    }
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createDefaultMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createDefaultCaps()};
+    setCaps(videoSink, caps);
+
+    EXPECT_TRUE(videoSink->priv->m_sourceAttached);
+
+    setNullState(pipeline, kSourceId);
+
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
 TEST_F(GstreamerMseVideoSinkTests, ShouldNotAttachSourceTwice)
 {
     RialtoMSEBaseSink *videoSink = createVideoSink();


### PR DESCRIPTION
Summary: Cache requests to set the immediate-output property until the pipeline is created. This needs to happen on both RialtoServer and rialto-gstreamer clients
Type: Fix  
Test Plan: UT, CT, native_build  
Jira: RIALTO-597