### PR TITLE
Require Audio Easing support on RialtoMSEAudioSink for Netflix (audio-fade and fade-volume)

### DIFF
--- a/source/Constants.h
+++ b/source/Constants.h
@@ -29,4 +29,5 @@ constexpr bool kDefaultLowLatency{false};
 constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
-constexpr uint32_t kDefaultFadeVolume{0};
+constexpr double kDefaultFadeVolume{0};
+constexpr const char* kDefaultAudioFade = "";

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -30,4 +30,4 @@ constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
 constexpr double kDefaultFadeVolume{0};
-constexpr const char* kDefaultAudioFade = "";
+constexpr const char *kDefaultAudioFade = "";

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -29,3 +29,4 @@ constexpr bool kDefaultLowLatency{false};
 constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
+constexpr uint32_t kDefaultFadeVolume{0};

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -29,5 +29,5 @@ constexpr bool kDefaultLowLatency{false};
 constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
-constexpr double kDefaultFadeVolume{0};
+constexpr double kDefaultFadeVolume{0.0};
 constexpr const char *kDefaultAudioFade = "";

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -29,5 +29,5 @@ constexpr bool kDefaultLowLatency{false};
 constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
-constexpr double kDefaultFadeVolume{0.0};
+constexpr uint32_t kDefaultFadeVolume{0};
 constexpr const char *kDefaultAudioFade = "";

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -17,6 +17,9 @@
  */
 
 #pragma once
+#include <MediaCommon.h>
 
 constexpr double kDefaultVolume{1.0};
+constexpr uint32_t kDefaultVolumeDuration{0};
+constexpr firebolt::rialto::EaseType kDefaultEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kDefaultMute{false};

--- a/source/Constants.h
+++ b/source/Constants.h
@@ -30,4 +30,4 @@ constexpr bool kDefaultSync{false};
 constexpr bool kDefaultSyncOff{false};
 constexpr int32_t kDefaultStreamSyncMode{0};
 constexpr uint32_t kDefaultFadeVolume{0};
-constexpr const char *kDefaultAudioFade = "";
+constexpr const char *kDefaultAudioFade = "100,0,L";

--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -672,9 +672,10 @@ bool GStreamerMSEMediaPlayerClient::renderFrame(RialtoMSEBaseSink *sink)
     return result;
 }
 
-void GStreamerMSEMediaPlayerClient::setVolume(double volume)
+void GStreamerMSEMediaPlayerClient::setVolume(double targetVolume, uint32_t volumeDuration,
+                                              firebolt::rialto::EaseType easeType)
 {
-    m_backendQueue->callInEventLoop([&]() { m_clientBackend->setVolume(volume); });
+    m_backendQueue->callInEventLoop([&]() { m_clientBackend->setVolume(targetVolume, volumeDuration, easeType); });
 }
 
 double GStreamerMSEMediaPlayerClient::getVolume()

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -294,7 +294,7 @@ public:
     void stopStreaming();
     void destroyClientBackend();
     bool renderFrame(RialtoMSEBaseSink *sink);
-    void setVolume(double volume);
+    void setVolume(double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType easeType);
     double getVolume();
     void setMute(bool mute);
     bool getMute();

--- a/source/MediaPlayerClientBackend.h
+++ b/source/MediaPlayerClientBackend.h
@@ -88,9 +88,12 @@ public:
 
     bool renderFrame() override { return m_mediaPlayerBackend->renderFrame(); }
 
-    bool setVolume(double volume) override { return m_mediaPlayerBackend->setVolume(volume); }
+    bool setVolume(double targetVolume, uint32_t volumeDuration, EaseType easeType) override
+    {
+        return m_mediaPlayerBackend->setVolume(targetVolume, volumeDuration, easeType);
+    }
 
-    bool getVolume(double &volume) override { return m_mediaPlayerBackend->getVolume(volume); }
+    bool getVolume(double &currentVolume) override { return m_mediaPlayerBackend->getVolume(currentVolume); }
 
     bool setMute(bool mute) override { return m_mediaPlayerBackend->setMute(mute); }
 

--- a/source/MediaPlayerClientBackendInterface.h
+++ b/source/MediaPlayerClientBackendInterface.h
@@ -47,8 +47,8 @@ public:
                const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment) = 0;
     virtual bool getPosition(int64_t &position) = 0;
     virtual bool renderFrame() = 0;
-    virtual bool setVolume(double volume) = 0;
-    virtual bool getVolume(double &volume) = 0;
+    virtual bool setVolume(double targetVolume, uint32_t volumeDuration, EaseType easeType) = 0;
+    virtual bool getVolume(double &currentVolume) = 0;
     virtual bool setMute(bool mute) = 0;
     virtual bool getMute(bool &mute) = 0;
     virtual bool flush(int32_t sourceId, bool resetTime) = 0;

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -79,7 +79,7 @@ static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *eleme
         }
         if (priv->isVolumeQueued)
         {
-            client->setVolume(priv->kDefaultVolume, priv->kDefaultVolumeDuration, priv->kDefaultEaseType);
+            client->setVolume(kDefaultVolume, kDefaultVolumeDuration, kDefaultEaseType);
             priv->isVolumeQueued = false;
         }
 
@@ -394,7 +394,7 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_uint(value, priv->kDefaultFadeVolume);
+            g_value_set_uint(value, kDefaultFadeVolume);
             return;
         }
         g_value_set_uint(value, static_cast<unsigned int>(client->getVolume()));

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -79,7 +79,7 @@ static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *eleme
         }
         if (priv->isVolumeQueued)
         {
-            client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
+            client->setVolume(priv->kDefaultVolume, priv->kDefaultVolumeDuration, priv->kDefaultEaseType);
             priv->isVolumeQueued = false;
         }
 
@@ -394,10 +394,10 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_uint(value, priv->fadeVolume);
+            g_value_set_uint(value, priv->kDefaultFadeVolume);
             return;
         }
-        g_value_set_uint(value, client->getVolume());
+        g_value_set_uint(value, static_cast<unsigned int>(client->getVolume()));
         break;
     }
     default:

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -89,7 +89,7 @@ static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *eleme
                 std::lock_guard<std::mutex> lock(priv->audioFadeConfigMutex);
                 audioFadeConfig = priv->audioFadeConfig;
             }
-            client->setVolume(audioFadeConfig.volume, audioFadeConfig.duration, audioFadeConfig.easeType);
+            client->setVolume(priv->targetVolume, audioFadeConfig.duration, audioFadeConfig.easeType);
             priv->isAudioFadeQueued = false;
         }
         break;
@@ -395,7 +395,7 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
             g_value_set_uint(value, kDefaultFadeVolume);
             return;
         }
-        g_value_set_uint(value, static_cast<unsigned int>(client->getVolume()));
+        g_value_set_uint(value, static_cast<unsigned int>(client->getVolume() * 100));
         break;
     }
     default:

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -394,14 +394,17 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_uint(value, priv->targetVolume);
+            g_value_set_double(value, priv->targetVolume);
             return;
         }
         if (!client->getVolume())
         {
             GST_ERROR_OBJECT(sink, "Could not get fade volume");
         }
-        g_value_set_uint(value, kDefaultFadeVolume);
+        else
+        {
+            g_value_set_double(value, client->getVolume());
+        }
         break;
     }
     default:
@@ -470,7 +473,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
             priv->isVolumeQueued = true;
             return;
         }
-        client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
+        client->setVolume(priv->targetVolume, kDefaultVolumeDuration, kDefaultEaseType);
         break;
     }
     case PROP_MUTE:
@@ -586,7 +589,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
 
         if (sscanf(audioFadeStr, "%lf,%u,%d", &volume, &duration, &easeTypeInt) != 3)
         {
-            GST_WARNING_OBJECT(object, "Failed to parse audio fade string: %s. Default values: volume=%lf, duration=%u, easeTypeInt=%d",
+            GST_WARNING_OBJECT(object, "Failed to parse audio fade string: %s. Continuing with values: volume=%lf, duration=%u, easeTypeInt=%d",
                                audioFadeStr, volume, duration, easeTypeInt);
         }
 

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -688,8 +688,8 @@ static void rialto_mse_audio_sink_class_init(RialtoMSEAudioSinkClass *klass)
         const std::string kAudioFadePropertyName{"audio-fade"};
         const std::string kFadeVolumePropertyName{"fade-volume"};
         const std::vector<std::string> kPropertyNamesToSearch{kLowLatencyPropertyName, kSyncPropertyName,
-                                                              kSyncOffPropertyName, kStreamSyncModePropertyName,
-                                                              kAudioFadePropertyName, kFadeVolumePropertyName};
+                                                              kSyncOffPropertyName,    kStreamSyncModePropertyName,
+                                                              kAudioFadePropertyName,  kFadeVolumePropertyName};
         std::vector<std::string> supportedProperties{
             mediaPlayerCapabilities->getSupportedProperties(firebolt::rialto::MediaSourceType::AUDIO,
                                                             kPropertyNamesToSearch)};
@@ -727,16 +727,16 @@ static void rialto_mse_audio_sink_class_init(RialtoMSEAudioSinkClass *klass)
             else if (kAudioFadePropertyName == *it)
             {
                 g_object_class_install_property(gobjectClass, PROP_AUDIO_FADE,
-                                                g_param_spec_string(kAudioFadePropertyName.c_str(),"audio fade",
-                                                                    "Start audio fade (vol[0-100],duration ms,easetype[(L)inear,Cubic(I)n,Cubic(O)ut])", 
-                                                                     kDefaultAudioFade, GParamFlags(G_PARAM_WRITABLE)));
+                                                g_param_spec_string(kAudioFadePropertyName.c_str(),
+                                                                    "audio fade", "Start audio fade (vol[0-100],duration ms,easetype[(L)inear,Cubic(I)n,Cubic(O)ut])",
+                                                                    kDefaultAudioFade, GParamFlags(G_PARAM_WRITABLE)));
             }
             else if (kFadeVolumePropertyName == *it)
             {
                 g_object_class_install_property(gobjectClass, PROP_FADE_VOLUME,
-                                                g_param_spec_uint(kFadeVolumePropertyName.c_str(), 
-                                                                  "fade volume", "Get current fade volume",
-                                                                  0, 100, kDefaultFadeVolume, G_PARAM_READABLE));
+                                                g_param_spec_uint(kFadeVolumePropertyName.c_str(), "fade volume",
+                                                                  "Get current fade volume", 0, 100, kDefaultFadeVolume,
+                                                                  G_PARAM_READABLE));
             }
             else
             {

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -408,7 +408,7 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
             g_value_set_uint(value, kDefaultFadeVolume);
             return;
         }
-        g_value_set_uint(value, static_cast<unsigned int>(client->getVolume() * 100));
+        g_value_set_uint(value, static_cast<uint32_t>(client->getVolume() * 100));
         break;
     }
     case PROP_LIMIT_BUFFERING_MS:
@@ -607,11 +607,11 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     case PROP_AUDIO_FADE:
     {
         const gchar *audioFadeStr = g_value_get_string(value);
-        uint32_t fadeVolume = static_cast<unsigned int>(kDefaultVolume * 100);
+        uint32_t fadeVolume = static_cast<uint32_t>(kDefaultVolume * 100);
         uint32_t duration = kDefaultVolumeDuration;
         int easeTypeInt = convertEaseTypeToInt(kDefaultEaseType);
 
-        int parsedItems = sscanf(audioFadeStr, "%d,%u,%d", &fadeVolume, &duration, &easeTypeInt);
+        int parsedItems = sscanf(audioFadeStr, "%u,%u,%d", &fadeVolume, &duration, &easeTypeInt);
 
         if (parsedItems == 0)
         {
@@ -620,7 +620,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
         }
         else if (parsedItems == 1 || parsedItems == 2)
         {
-            GST_WARNING_OBJECT(object, "Partially parsed audio fade string: %s. Continuing with values: fadeVolume=%d, duration=%u, easeTypeInt=%d",
+            GST_WARNING_OBJECT(object, "Partially parsed audio fade string: %s. Continuing with values: fadeVolume=%u, duration=%u, easeTypeInt=%d",
                                audioFadeStr, fadeVolume, duration, easeTypeInt);
         }
 
@@ -751,9 +751,9 @@ static void rialto_mse_audio_sink_class_init(RialtoMSEAudioSinkClass *klass)
         const std::string kAudioFadePropertyName{"audio-fade"};
         const std::string kFadeVolumePropertyName{"fade-volume"};
         const std::string kBufferingLimitPropertyName{"limit-buffering-ms"};
-        const std::vector<std::string> kPropertyNamesToSearch{kLowLatencyPropertyName, kSyncPropertyName,
-                                                              kSyncOffPropertyName,    kStreamSyncModePropertyName,
-                                                              kBufferingLimitPropertyName, kAudioFadePropertyName,  
+        const std::vector<std::string> kPropertyNamesToSearch{kLowLatencyPropertyName,     kSyncPropertyName,
+                                                              kSyncOffPropertyName,        kStreamSyncModePropertyName,
+                                                              kBufferingLimitPropertyName, kAudioFadePropertyName,
                                                               kFadeVolumePropertyName};
         std::vector<std::string> supportedProperties{
             mediaPlayerCapabilities->getSupportedProperties(firebolt::rialto::MediaSourceType::AUDIO,

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -72,7 +72,7 @@ static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *eleme
         }
         if (priv->isVolumeQueued)
         {
-            client->setVolume(priv->volume);
+            client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
             priv->isVolumeQueued = false;
         }
         if (priv->isMuteQueued)
@@ -283,7 +283,7 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_double(value, priv->volume);
+            g_value_set_double(value, priv->targetVolume);
             return;
         }
         g_value_set_double(value, client->getVolume());
@@ -329,14 +329,14 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     {
     case PROP_VOLUME:
     {
-        priv->volume = g_value_get_double(value);
+        priv->targetVolume = g_value_get_double(value);
         if (!client)
         {
             GST_DEBUG_OBJECT(object, "Enqueue volume setting");
             priv->isVolumeQueued = true;
             return;
         }
-        client->setVolume(priv->volume);
+        client->setVolume(priv->targetVolume, priv->volumeDuration, priv->easeType);
         break;
     }
     case PROP_MUTE:

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -543,7 +543,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     case PROP_LOW_LATENCY:
     {
         priv->lowLatency = g_value_get_boolean(value);
-        if (!client || !basePriv->m_sourceAttached)
+        if (!client)
         {
             GST_DEBUG_OBJECT(object, "Enqueue low latency setting");
             priv->isLowLatencyQueued = true;
@@ -559,7 +559,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     case PROP_SYNC:
     {
         priv->sync = g_value_get_boolean(value);
-        if (!client || !basePriv->m_sourceAttached)
+        if (!client)
         {
             GST_DEBUG_OBJECT(object, "Enqueue sync setting");
             priv->isSyncQueued = true;
@@ -575,7 +575,7 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
     case PROP_SYNC_OFF:
     {
         priv->syncOff = g_value_get_boolean(value);
-        if (!client || !basePriv->m_sourceAttached)
+        if (!client)
         {
             GST_DEBUG_OBJECT(object, "Enqueue sync off setting");
             priv->isSyncOffQueued = true;
@@ -624,7 +624,13 @@ static void rialto_mse_audio_sink_set_property(GObject *object, guint propId, co
                                audioFadeStr, fadeVolume, duration, easeTypeInt);
         }
 
+        if (fadeVolume > 100)
+        {
+            GST_WARNING_OBJECT(object, "Fade volume is greater than 100. Setting it to 100.");
+            fadeVolume = 100;
+        }
         double volume = fadeVolume / 100.0;
+
         firebolt::rialto::EaseType easeType = convertIntToEaseType(easeTypeInt);
         {
             std::lock_guard<std::mutex> lock(priv->audioFadeConfigMutex);

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -394,18 +394,18 @@ static void rialto_mse_audio_sink_get_property(GObject *object, guint propId, GV
     {
         if (!client)
         {
-            g_value_set_double(value, priv->targetVolume);
+            g_value_set_uint(value, priv->targetVolume);
             return;
         }
-        if (!client->getVolume())
+        uint fadeVolume = client->getVolume();
+        if (!fadeVolume)
         {
             GST_ERROR_OBJECT(sink, "Could not get fade volume");
         }
         else
         {
-            g_value_set_double(value, client->getVolume());
+            g_value_set_uint(value, fadeVolume);
         }
-        break;
     }
     default:
     {

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -26,7 +26,9 @@ G_BEGIN_DECLS
 
 struct _RialtoMSEAudioSinkPrivate
 {
-    std::atomic<double> volume = kDefaultVolume;
+    std::atomic<double> targetVolume = kDefaultVolume;
+    std::atomic<uint32_t> volumeDuration = kDefaultVolumeDuration;
+    std::atomic<firebolt::rialto::EaseType> easeType = kDefaultEaseType;
     std::atomic_bool mute = kDefaultMute;
     std::atomic_bool isVolumeQueued = false;
     std::atomic_bool isMuteQueued = false;

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -40,6 +40,12 @@ struct _RialtoMSEAudioSinkPrivate
     std::atomic_bool isSyncOffQueued = false;
     std::atomic<int32_t> streamSyncMode = kDefaultStreamSyncMode;
     std::atomic_bool isStreamSyncModeQueued = false;
+    // std::atomic<const gchar*> audioFade = nullptr;
+    std::atomic_bool isAudioFadeQueued = false;
+    std::atomic<std::string> audioFade = kDefaultAudioFade;
+    std::atomic<uint32_t> fadeVolume = kDefaultFadeVolume;
+    
+    
 };
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -21,6 +21,7 @@
 #include "Constants.h"
 #include <atomic>
 #include <gst/gst.h>
+#include <mutex>
 
 G_BEGIN_DECLS
 
@@ -47,10 +48,9 @@ struct _RialtoMSEAudioSinkPrivate
     std::atomic_bool isSyncOffQueued = false;
     std::atomic<int32_t> streamSyncMode = kDefaultStreamSyncMode;
     std::atomic_bool isStreamSyncModeQueued = false;
-    std::atomic<const gchar*> audioFade = kDefaultAudioFade;
     AudioFadeConfig audioFadeConfig;
+    std::mutex audioFadeConfigMutex;
     std::atomic_bool isAudioFadeQueued = false;
-    std::atomic<uint32_t> fadeVolume = kDefaultFadeVolume;
 };
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -51,7 +51,6 @@ struct _RialtoMSEAudioSinkPrivate
     AudioFadeConfig audioFadeConfig;
     std::mutex audioFadeConfigMutex;
     std::atomic_bool isAudioFadeQueued = false;
-    std::atomic<uint32_t> fadeVolume = kDefaultFadeVolume;
 };
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -35,8 +35,6 @@ struct AudioFadeConfig
 struct _RialtoMSEAudioSinkPrivate
 {
     std::atomic<double> targetVolume = kDefaultVolume;
-    std::atomic<uint32_t> volumeDuration = kDefaultVolumeDuration;
-    std::atomic<firebolt::rialto::EaseType> easeType = kDefaultEaseType;
     std::atomic_bool mute = kDefaultMute;
     std::atomic_bool isVolumeQueued = false;
     std::atomic_bool isMuteQueued = false;

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -51,6 +51,7 @@ struct _RialtoMSEAudioSinkPrivate
     AudioFadeConfig audioFadeConfig;
     std::mutex audioFadeConfigMutex;
     std::atomic_bool isAudioFadeQueued = false;
+    std::atomic<uint32_t> fadeVolume = kDefaultFadeVolume;
 };
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEAudioSinkPrivate.h
+++ b/source/RialtoGStreamerMSEAudioSinkPrivate.h
@@ -24,6 +24,13 @@
 
 G_BEGIN_DECLS
 
+struct AudioFadeConfig
+{
+    double volume;
+    uint32_t duration;
+    firebolt::rialto::EaseType easeType;
+};
+
 struct _RialtoMSEAudioSinkPrivate
 {
     std::atomic<double> targetVolume = kDefaultVolume;
@@ -40,12 +47,10 @@ struct _RialtoMSEAudioSinkPrivate
     std::atomic_bool isSyncOffQueued = false;
     std::atomic<int32_t> streamSyncMode = kDefaultStreamSyncMode;
     std::atomic_bool isStreamSyncModeQueued = false;
-    // std::atomic<const gchar*> audioFade = nullptr;
+    std::atomic<const gchar*> audioFade = kDefaultAudioFade;
+    AudioFadeConfig audioFadeConfig;
     std::atomic_bool isAudioFadeQueued = false;
-    std::atomic<std::string> audioFade = kDefaultAudioFade;
     std::atomic<uint32_t> fadeVolume = kDefaultFadeVolume;
-    
-    
 };
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEBaseSinkPrivate.h
+++ b/source/RialtoGStreamerMSEBaseSinkPrivate.h
@@ -61,7 +61,6 @@ struct _RialtoMSEBaseSinkPrivate
     GstCaps *m_caps = nullptr;
 
     std::atomic<int32_t> m_sourceId;
-    std::atomic<double> m_currentVolume;
     std::queue<GstSample *> m_samples;
     bool m_isEos = false;
     std::atomic<bool> m_isFlushOngoing;

--- a/source/RialtoGStreamerMSEBaseSinkPrivate.h
+++ b/source/RialtoGStreamerMSEBaseSinkPrivate.h
@@ -61,6 +61,7 @@ struct _RialtoMSEBaseSinkPrivate
     GstCaps *m_caps = nullptr;
 
     std::atomic<int32_t> m_sourceId;
+    std::atomic<double> m_currentVolume;
     std::queue<GstSample *> m_samples;
     bool m_isEos = false;
     std::atomic<bool> m_isFlushOngoing;

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,8 +51,8 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double volume), (override));
-    MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
+    MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));
     MOCK_METHOD(bool, flush, (int32_t sourceId, bool resetTime), (override));

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,7 +51,7 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type), (override));
     MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -51,7 +51,7 @@ public:
     MOCK_METHOD(AddSegmentStatus, addSegment,
                 (uint32_t needDataRequestId, const std::unique_ptr<MediaSegment> &mediaSegment), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, EaseType type), (override));
     MOCK_METHOD(bool, getVolume, (double &currentVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));

--- a/tests/mocks/MediaPlayerClientBackendMock.h
+++ b/tests/mocks/MediaPlayerClientBackendMock.h
@@ -50,8 +50,9 @@ public:
                 (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
-    MOCK_METHOD(bool, setVolume, (double volume), (override));
-    MOCK_METHOD(bool, getVolume, (double &volume), (override));
+    MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type),
+                (override));
+    MOCK_METHOD(bool, getVolume, (double &curretVolume), (override));
     MOCK_METHOD(bool, setMute, (bool mute), (override));
     MOCK_METHOD(bool, getMute, (bool &mute), (override));
     MOCK_METHOD(bool, flush, (int32_t sourceId, bool resetTime), (override));

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -465,7 +465,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldQueueAudioFadeIfClientIsNull)
     RialtoMSEBaseSink *audioSink = createAudioSink();
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
-    const gchar *kAudioFade{"1,100,0"};
+    const gchar *kAudioFade{"1,100,2"};
     g_object_set(audioSink, "audio-fade", kAudioFade, nullptr);
 
     setPausedState(pipeline, audioSink);
@@ -474,7 +474,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldQueueAudioFadeIfClientIsNull)
 
     const gdouble kVolume{1.0};
     const guint kVolumeDuration{100};
-    const firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
+    const firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_OUT_CUBIC};
     EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
 
     GstCaps *caps{createAudioCaps()};
@@ -522,7 +522,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldApplyAudioFadeWhenClientIsAvailable)
     gdouble targetVolume{0.5};
     guint volumeDuration{1000};
     firebolt::rialto::EaseType easeType{firebolt::rialto::EaseType::EASE_IN_CUBIC};
-    const gchar *kFadeConfig = "0.5,1000,1";
+    const gchar *kFadeConfig{"0.5,1000,1"};
 
     EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, volumeDuration, easeType)).WillOnce(Return(true));
     g_object_set(textContext.m_sink, "audio-fade", kFadeConfig, nullptr);

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -451,10 +451,11 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     guint fadeVolume{0};
-    constexpr guint kFadeVolume{50};
-    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kFadeVolume), Return(true)));
+    constexpr guint kFadeVolume{5};
+    constexpr guint kExpectedFadeVolume{5};
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kFadeVolume / 100.0), Return(true)));
     g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
-    EXPECT_EQ(fadeVolume, kFadeVolume);
+    EXPECT_EQ(fadeVolume, kExpectedFadeVolume);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
     gst_object_unref(textContext.m_pipeline);

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -347,7 +347,10 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldSetVolume)
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     constexpr gdouble kVolume{0.8};
-    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    constexpr uint32_t kVolumeDuration{0};
+    constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
+
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     g_object_set(textContext.m_sink, "volume", kVolume, nullptr);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
@@ -360,9 +363,12 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldSetCachedVolume)
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
     constexpr gdouble kVolume{0.8};
+    constexpr uint32_t kVolumeDuration{0};
+    constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
+
     g_object_set(audioSink, "volume", kVolume, nullptr);
 
-    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     load(pipeline);
     EXPECT_EQ(GST_STATE_CHANGE_ASYNC, gst_element_set_state(pipeline, GST_STATE_PAUSED));
 

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -504,9 +504,10 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldWarnWhenParsingAudioFadeStringWithOneVa
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     const gchar *kPartialFadeConfig{"0.5"};
-    gdouble volume{0.5};
+    gdouble targetVolume{0.5};
 
-    EXPECT_CALL(m_mediaPipelineMock, setVolume(volume, kDefaultVolumeDuration, kDefaultEaseType)).WillOnce(Return(true));
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, kDefaultVolumeDuration, kDefaultEaseType))
+        .WillOnce(Return(true));
 
     g_object_set(textContext.m_sink, "audio-fade", kPartialFadeConfig, nullptr);
 
@@ -520,8 +521,8 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldApplyAudioFadeWhenClientIsAvailable)
 
     gdouble targetVolume{0.5};
     guint volumeDuration{1000};
-    firebolt::rialto::EaseType easeType{firebolt::rialto::EaseType::EASE_LINEAR};
-    const gchar *kFadeConfig = "0.5,1000,0";
+    firebolt::rialto::EaseType easeType{firebolt::rialto::EaseType::EASE_IN_CUBIC};
+    const gchar *kFadeConfig = "0.5,1000,1";
 
     EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, volumeDuration, easeType)).WillOnce(Return(true));
     g_object_set(textContext.m_sink, "audio-fade", kFadeConfig, nullptr);

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -460,28 +460,23 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
     gst_object_unref(textContext.m_pipeline);
 }
 
-TEST_F(GstreamerMseAudioSinkTests, ShouldQueueAudioFadeIfClientIsNull)
+TEST_F(GstreamerMseAudioSinkTests, ShouldSetCacheAudioFade)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
-    const gchar *kAudioFade{"1,100,2"};
-    g_object_set(audioSink, "audio-fade", kAudioFade, nullptr);
-
-    setPausedState(pipeline, audioSink);
-    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
-    allSourcesWillBeAttached();
-
     const gdouble kVolume{1.0};
     const guint kVolumeDuration{100};
     const firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_OUT_CUBIC};
+    const gchar *kAudioFade{"1,100,2"};
+
+    g_object_set(audioSink, "audio-fade", kAudioFade, nullptr);
+
     EXPECT_CALL(m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
+    load(pipeline);
+    EXPECT_EQ(GST_STATE_CHANGE_ASYNC, gst_element_set_state(pipeline, GST_STATE_PAUSED));
 
-    GstCaps *caps{createAudioCaps()};
-    setCaps(audioSink, caps);
-    gst_caps_unref(caps);
-
-    setNullState(pipeline, kSourceId);
+    setNullState(pipeline, kUnknownSourceId);
 
     gst_object_unref(pipeline);
 }

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -452,10 +452,10 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
 
     guint fadeVolume{0};
     constexpr guint kFadeVolume{5};
-    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(5 / 100.0), Return(true)));
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kFadeVolume / 100.0), Return(true)));
     g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
     EXPECT_EQ(fadeVolume, kFadeVolume);
-    
+
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
     gst_object_unref(textContext.m_pipeline);
 }

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -452,10 +452,9 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
 
     guint fadeVolume{0};
     constexpr guint kFadeVolume{5};
-    constexpr guint kExpectedFadeVolume{5};
-    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kFadeVolume / 100.0), Return(true)));
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(5 / 100.0), Return(true)));
     g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
-    EXPECT_EQ(fadeVolume, kExpectedFadeVolume);
+    EXPECT_EQ(fadeVolume, kFadeVolume);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
     gst_object_unref(textContext.m_pipeline);
@@ -466,7 +465,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldSetCacheAudioFade)
     RialtoMSEBaseSink *audioSink = createAudioSink();
     GstElement *pipeline = createPipelineWithSink(audioSink);
 
-    const gdouble kVolume{1.0};
+    const gdouble kVolume{0.01};
     const guint kVolumeDuration{100};
     const firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_OUT_CUBIC};
     const gchar *kAudioFade{"1,100,2"};
@@ -499,7 +498,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldWarnWhenParsingAudioFadeStringWithOneVa
 {
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
-    const gchar *kPartialFadeConfig{"0.5"};
+    const gchar *kPartialFadeConfig{"50"};
     gdouble targetVolume{0.5};
 
     EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, kDefaultVolumeDuration, kDefaultEaseType))
@@ -518,7 +517,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldApplyAudioFadeWhenClientIsAvailable)
     gdouble targetVolume{0.5};
     guint volumeDuration{1000};
     firebolt::rialto::EaseType easeType{firebolt::rialto::EaseType::EASE_IN_CUBIC};
-    const gchar *kFadeConfig{"0.5,1000,1"};
+    const gchar *kFadeConfig{"50,1000,1"};
 
     EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, volumeDuration, easeType)).WillOnce(Return(true));
     g_object_set(textContext.m_sink, "audio-fade", kFadeConfig, nullptr);

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -18,8 +18,8 @@
 
 #include "Constants.h"
 #include "Matchers.h"
+#include "RialtoGStreamerMSEAudioSinkPrivate.h"
 #include "RialtoGStreamerMSEBaseSinkPrivate.h"
-#include "RialtoGStreamerMSEAudioSinkPrivate.h" 
 #include "RialtoGstTest.h"
 
 using testing::_;
@@ -438,9 +438,9 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetStreamSyncModeProperty)
 TEST_F(GstreamerMseAudioSinkTests, ShouldReturnDefaultFadeVolumeValueWhenPipelineIsBelowPausedState)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();
-    
+
     guint fadeVolume{0};
-    g_object_get(audioSink, "fade-volume", &fadeVolume, nullptr); 
+    g_object_get(audioSink, "fade-volume", &fadeVolume, nullptr);
     EXPECT_EQ(kDefaultFadeVolume, fadeVolume);
 
     gst_object_unref(audioSink);
@@ -491,7 +491,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldFailWhenParsingInvalidAudioFadeString)
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     const gchar *kInvalidFadeConfig{"invalid"};
-    
+
     EXPECT_CALL(m_mediaPipelineMock, setVolume(_, _, _)).Times(0);
     g_object_set(textContext.m_sink, "audio-fade", kInvalidFadeConfig, nullptr);
 
@@ -516,18 +516,18 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldWarnWhenParsingAudioFadeStringWithOneVa
 
 TEST_F(GstreamerMseAudioSinkTests, ShouldApplyAudioFadeWhenClientIsAvailable)
 {
-   TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
+    TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
     gdouble targetVolume{0.5};
     guint volumeDuration{1000};
     firebolt::rialto::EaseType easeType{firebolt::rialto::EaseType::EASE_LINEAR};
-    const gchar *kFadeConfig = "0.5,1000,0"; 
+    const gchar *kFadeConfig = "0.5,1000,0";
 
-   EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, volumeDuration, easeType)).WillOnce(Return(true));
-   g_object_set(textContext.m_sink, "audio-fade", kFadeConfig, nullptr);
+    EXPECT_CALL(m_mediaPipelineMock, setVolume(targetVolume, volumeDuration, easeType)).WillOnce(Return(true));
+    g_object_set(textContext.m_sink, "audio-fade", kFadeConfig, nullptr);
 
-   setNullState(textContext.m_pipeline, textContext.m_sourceId);
-   gst_object_unref(textContext.m_pipeline);
+    setNullState(textContext.m_pipeline, textContext.m_sourceId);
+    gst_object_unref(textContext.m_pipeline);
 }
 
 TEST_F(GstreamerMseAudioSinkTests, ShouldFailToSetVolumePropertyWhenPipelineIsBelowPausedState)

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -439,7 +439,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldReturnDefaultFadeVolumeValueWhenPipelin
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();
 
-    guint fadeVolume{0};
+    guint fadeVolume{1};
     g_object_get(audioSink, "fade-volume", &fadeVolume, nullptr);
     EXPECT_EQ(kDefaultFadeVolume, fadeVolume);
 

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -19,6 +19,7 @@
 #include "Constants.h"
 #include "Matchers.h"
 #include "RialtoGStreamerMSEBaseSinkPrivate.h"
+#include "RialtoGStreamerMSEAudioSinkPrivate.h" 
 #include "RialtoGstTest.h"
 
 using testing::_;
@@ -429,6 +430,45 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetStreamSyncModeProperty)
     EXPECT_CALL(m_mediaPipelineMock, getStreamSyncMode(_)).WillOnce(DoAll(SetArgReferee<0>(1), Return(true)));
     g_object_get(textContext.m_sink, "stream-sync-mode", &streamSyncMode, nullptr);
     EXPECT_EQ(streamSyncMode, 1);
+
+    setNullState(textContext.m_pipeline, textContext.m_sourceId);
+    gst_object_unref(textContext.m_pipeline);
+}
+
+TEST_F (GstreamerMseAudioSinkTests, ShouldReturnDefaultFadeVolumeValueWhenPipelineIsBelowPausedState)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    
+    guint fadeVolume{0};
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kDefaultFadeVolume), Return(false)));
+    g_object_get(audioSink, "fade-volume", &fadeVolume, nullptr); 
+    EXPECT_EQ(fadeVolume, kDefaultFadeVolume);
+
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseAudioSinkTests, ShouldReturnDefaultFadeVolumePropertyOnRialtoFailure)
+{
+    TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
+
+    guint fadeVolume{0};
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kDefaultFadeVolume), Return(true)));
+    g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
+    EXPECT_EQ(fadeVolume, kDefaultFadeVolume);
+
+    setNullState(textContext.m_pipeline, textContext.m_sourceId);
+    gst_object_unref(textContext.m_pipeline);
+}
+
+TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
+{
+    TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
+
+    guint fadeVolume{0};
+    constexpr guint kFadeVolume{50};
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kFadeVolume), Return(true)));
+    g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
+    EXPECT_EQ(fadeVolume, kFadeVolume);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
     gst_object_unref(textContext.m_pipeline);

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -48,6 +48,8 @@ const std::string kUrl{"mse://1"};
 constexpr firebolt::rialto::MediaType kMediaType{firebolt::rialto::MediaType::MSE};
 const std::string kMimeType{""};
 constexpr double kVolume{1.0};
+constexpr uint32_t kVolumeDuration{30};
+constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kMute{true};
 constexpr bool kResetTime{true};
 constexpr uint32_t kDuration{30};
@@ -1106,8 +1108,8 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldRenderFrame)
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetVolume)
 {
     expectCallInEventLoop();
-    EXPECT_CALL(*m_mediaPlayerClientBackendMock, setVolume(kVolume)).WillOnce(Return(true));
-    m_sut->setVolume(kVolume);
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
+    m_sut->setVolume(kVolume, kVolumeDuration, kEaseType);
 }
 
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetVolume)

--- a/tests/ut/MediaPlayerClientBackendTests.cpp
+++ b/tests/ut/MediaPlayerClientBackendTests.cpp
@@ -39,6 +39,8 @@ namespace
 {
 constexpr VideoRequirements kVideoRequirements{1024, 768};
 constexpr double kVolume{0.7};
+constexpr uint32_t kVolumeDuration{1000};
+constexpr firebolt::rialto::EaseType kEaseType{firebolt::rialto::EaseType::EASE_LINEAR};
 constexpr bool kMute{true};
 MATCHER_P(PtrMatcher, ptr, "")
 {
@@ -219,10 +221,10 @@ TEST_F(MediaPlayerClientBackendTests, ShouldRenderFrame)
 
 TEST_F(MediaPlayerClientBackendTests, ShouldSetVolume)
 {
-    EXPECT_CALL(*m_mediaPipelineMock, setVolume(kVolume)).WillOnce(Return(true));
+    EXPECT_CALL(*m_mediaPipelineMock, setVolume(kVolume, kVolumeDuration, kEaseType)).WillOnce(Return(true));
     initializeMediaPipeline();
     ASSERT_TRUE(m_sut.isMediaPlayerBackendCreated());
-    EXPECT_TRUE(m_sut.setVolume(kVolume));
+    EXPECT_TRUE(m_sut.setVolume(kVolume, kVolumeDuration, kEaseType));
 }
 
 TEST_F(MediaPlayerClientBackendTests, ShouldGetVolume)


### PR DESCRIPTION
Summary: Require Audio Easing support on RialtoMSEAudioSink for Netflix - audio-fade and fade-volume
Type: Feature
Test Plan: UT
Jira: RIALTO-593