### PR TITLE
Fix web audio by disabling xraw until a better fix is found

### DIFF
--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -44,7 +44,7 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},
          {"audio/b-wav", {"audio/b-wav"}},
-#ifdef RAILTO_ENABLE_X_RAW
+#ifdef RIALTO_ENABLE_X_RAW
          {"audio/x-raw", {"audio/x-raw"}},
 #endif
          {"video/h264", {"video/x-h264"}},

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -31,7 +31,7 @@
 // When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
 // selecting the MSE sink instead of webaudio (because it supports x-raw)
 //
-// When this fix is found, please remove this MACRO from the code
+// When a better fix is found, please remove this MACRO from the code
 #define RIALTO_ENABLE_X_RAW
 #endif
 

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -22,6 +22,19 @@
 #include <unordered_set>
 
 #define GST_CAT_DEFAULT rialtoGStreamerCat
+
+#if 0
+// The x-raw capability is disabled until a workaround is found for the following...
+//
+// Returning an x-raw capability (which would work) has the side-effect of
+// breaking the WebAudio YT cert test.
+// When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
+// selecting the MSE sink instead of webaudio (because it supports x-raw)
+//
+// When this fix is found, please remove this MACRO from the code
+#define RIALTO_ENABLE_X_RAW
+#endif
+
 void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
                                           const std::vector<std::string> &supportedMimeTypes)
 {
@@ -31,7 +44,9 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},
          {"audio/b-wav", {"audio/b-wav"}},
+#ifdef RAILTO_ENABLE_X_RAW
          {"audio/x-raw", {"audio/x-raw"}},
+#endif
          {"video/h264", {"video/x-h264"}},
          {"video/h265", {"video/x-h265"}},
          {"video/x-av1", {"video/x-av1"}},

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -32,6 +32,7 @@
 // selecting the MSE sink instead of webaudio (because it supports x-raw)
 //
 // When a better fix is found, please remove this MACRO from the code
+// (NOTE: this macro is used in at least one other file, please search for it)
 #define RIALTO_ENABLE_X_RAW
 #endif
 

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -258,6 +258,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithBwav)
     gst_object_unref(pipeline);
 }
 
+#ifdef RAILTO_ENABLE_X_RAW
 TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
 {
     constexpr firebolt::rialto::Format kExpectedFormat{firebolt::rialto::Format::S32BE};
@@ -288,6 +289,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
     gst_caps_unref(caps);
     gst_object_unref(pipeline);
 }
+#endif
 
 TEST_F(GstreamerMseAudioSinkTests, ShouldReachPausedState)
 {

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -258,7 +258,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithBwav)
     gst_object_unref(pipeline);
 }
 
-#ifdef RAILTO_ENABLE_X_RAW
+#ifdef RIALTO_ENABLE_X_RAW
 TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
 {
     constexpr firebolt::rialto::Format kExpectedFormat{firebolt::rialto::Format::S32BE};


### PR DESCRIPTION
Summary: Fix for web audio (not playing in the ytcert tests) by disabling xraw (until a better fix is found)
Type: Fix  
Test Plan: UT, CT, test ytcert on US XiOne
Jira: NO-JIRA