### PR TITLE
Allow to enable x-raw for mse audio in a build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_compile_definitions(TAGS="${TAGS}")
 add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
 
 # The x-raw capability is disabled until a workaround is found for the following...
+# Task to remove a workaround is RIALTO-683.
 # 
 # Returning an x-raw capability (which would work) has the side-effect of
 # breaking the WebAudio YT cert test.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,17 @@ add_compile_definitions(TAGS="${TAGS}")
 # Preprocesser Variable
 add_compile_definitions(COMMIT_ID="${COMMIT_ID}")
 
+# The x-raw capability is disabled until a workaround is found for the following...
+# 
+# Returning an x-raw capability (which would work) has the side-effect of
+# breaking the WebAudio YT cert test.
+# When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
+# selecting the MSE sink instead of webaudio (because it supports x-raw)
+if ( RIALTO_ENABLE_X_RAW )
+    message("RIALTO_ENABLE_X_RAW IS ENABLED")
+    add_compile_definitions( RIALTO_ENABLE_X_RAW )
+endif()
+
 # Config and target for building the unit tests
 if( NOT CMAKE_BUILD_FLAG STREQUAL "UnitTests" )
     add_subdirectory(source)

--- a/build_ut.py
+++ b/build_ut.py
@@ -133,7 +133,7 @@ def main ():
 # Build the target executables
 def buildTargets (suites, outputDir, resultsFile, debug, coverage, branch):
     # Run cmake
-    cmakeCmd = ["cmake", "-B", outputDir , "-DCMAKE_BUILD_FLAG=UnitTests", "-DBUILD_BRANCH=" + str(branch)]
+    cmakeCmd = ["cmake", "-B", outputDir , "-DCMAKE_BUILD_FLAG=UnitTests", "-DRIALTO_ENABLE_X_RAW=1", "-DBUILD_BRANCH=" + str(branch)]
     # Coverage
     if coverage:
         cmakeCmd.append("-DCOVERAGE_ENABLED=1")

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -22,6 +22,20 @@
 #include <unordered_set>
 
 #define GST_CAT_DEFAULT rialtoGStreamerCat
+
+#if 0
+// The x-raw capability is disabled until a workaround is found for the following...
+//
+// Returning an x-raw capability (which would work) has the side-effect of
+// breaking the WebAudio YT cert test.
+// When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
+// selecting the MSE sink instead of webaudio (because it supports x-raw)
+//
+// When a better fix is found, please remove this MACRO from the code
+// (NOTE: this macro is used in at least one other file, please search for it)
+#define RIALTO_ENABLE_X_RAW
+#endif
+
 void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
                                           const std::vector<std::string> &supportedMimeTypes)
 {
@@ -31,7 +45,9 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},
          {"audio/b-wav", {"audio/b-wav"}},
+#ifdef RIALTO_ENABLE_X_RAW
          {"audio/x-raw", {"audio/x-raw"}},
+#endif
          {"video/h264", {"video/x-h264"}},
          {"video/h265", {"video/x-h265"}},
          {"video/x-av1", {"video/x-av1"}},

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -22,20 +22,6 @@
 #include <unordered_set>
 
 #define GST_CAT_DEFAULT rialtoGStreamerCat
-
-#if 0
-// The x-raw capability is disabled until a workaround is found for the following...
-//
-// Returning an x-raw capability (which would work) has the side-effect of
-// breaking the WebAudio YT cert test.
-// When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
-// selecting the MSE sink instead of webaudio (because it supports x-raw)
-//
-// When a better fix is found, please remove this MACRO from the code
-// (NOTE: this macro is used in at least one other file, please search for it)
-#define RIALTO_ENABLE_X_RAW
-#endif
-
 void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
                                           const std::vector<std::string> &supportedMimeTypes)
 {
@@ -45,9 +31,7 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},
          {"audio/b-wav", {"audio/b-wav"}},
-#ifdef RIALTO_ENABLE_X_RAW
          {"audio/x-raw", {"audio/x-raw"}},
-#endif
          {"video/h264", {"video/x-h264"}},
          {"video/h265", {"video/x-h265"}},
          {"video/x-av1", {"video/x-av1"}},

--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -23,19 +23,6 @@
 
 #define GST_CAT_DEFAULT rialtoGStreamerCat
 
-#if 0
-// The x-raw capability is disabled until a workaround is found for the following...
-//
-// Returning an x-raw capability (which would work) has the side-effect of
-// breaking the WebAudio YT cert test.
-// When WebAudio in cobalt creates the audio sink, it uses autoaudiosink which is
-// selecting the MSE sink instead of webaudio (because it supports x-raw)
-//
-// When a better fix is found, please remove this MACRO from the code
-// (NOTE: this macro is used in at least one other file, please search for it)
-#define RIALTO_ENABLE_X_RAW
-#endif
-
 void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
                                           const std::vector<std::string> &supportedMimeTypes)
 {

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -258,6 +258,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithBwav)
     gst_object_unref(pipeline);
 }
 
+#ifdef RIALTO_ENABLE_X_RAW
 TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
 {
     constexpr firebolt::rialto::Format kExpectedFormat{firebolt::rialto::Format::S32BE};
@@ -288,6 +289,7 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
     gst_caps_unref(caps);
     gst_object_unref(pipeline);
 }
+#endif
 
 TEST_F(GstreamerMseAudioSinkTests, ShouldReachPausedState)
 {

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -258,7 +258,6 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithBwav)
     gst_object_unref(pipeline);
 }
 
-#ifdef RIALTO_ENABLE_X_RAW
 TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
 {
     constexpr firebolt::rialto::Format kExpectedFormat{firebolt::rialto::Format::S32BE};
@@ -289,7 +288,6 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithXraw)
     gst_caps_unref(caps);
     gst_object_unref(pipeline);
 }
-#endif
 
 TEST_F(GstreamerMseAudioSinkTests, ShouldReachPausedState)
 {


### PR DESCRIPTION
Summary: Allow to enable x-raw for mse audio in a build flag
Type: Fix
Test Plan: UT, CT, Fullstack
Jira: RIALTO-668