### PR TITLE
Fixed rialto version reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 # Retrieve release tag(s)
 execute_process(
-    COMMAND bash -c "git tag --list --contains ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    COMMAND bash -c "git tag --list --points-at ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
     OUTPUT_VARIABLE TAGS
     OUTPUT_STRIP_TRAILING_WHITESPACE 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 # Retrieve release tag(s)
 execute_process(
-    COMMAND bash -c "git tag --list --points-at ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
+    COMMAND bash -c "git tag --points-at ${SRCREV} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}  
     OUTPUT_VARIABLE TAGS
     OUTPUT_STRIP_TRAILING_WHITESPACE 


### PR DESCRIPTION
Summary: Print only the tags directly associated with the given commit for version reporting
Type: Fix
Test Plan: None
Jira: ENTDAI-919