### PR TITLE
Limit samples queue size for WebAudio

### DIFF
--- a/source/GStreamerWebAudioPlayerClient.h
+++ b/source/GStreamerWebAudioPlayerClient.h
@@ -222,6 +222,17 @@ private:
     uint32_t m_frameSize;
 
     /**
+     * @brief The mutex protecting m_dataBuffers size reads
+     */
+    std::mutex m_queueSizeMutex;
+
+    /**
+     * @brief The condition variable used to block webaudio chain function
+     *        when m_dataBuffers queue size is too large
+     */
+    std::condition_variable m_queueSizeCv;
+
+    /**
      * @brief The current web audio player mime type.
      */
     std::string m_mimeType;

--- a/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
+++ b/tests/ut/GstreamerWebAudioPlayerClientTests.cpp
@@ -76,7 +76,7 @@ constexpr firebolt::rialto::WebAudioPcmConfig kFloatFormatConfig{kRate, kChannel
 const std::string kLittleEndian{"U12LE"};
 constexpr firebolt::rialto::WebAudioPcmConfig kLittleEndianFormatConfig{kRate, kChannels, 12, false, false, false};
 const std::vector<uint8_t> kBytes{1, 2, 3, 4, 5, 6, 7, 8};
-constexpr std::chrono::milliseconds kTimeout{100};
+constexpr std::chrono::milliseconds kTimeout{10};
 constexpr auto kTimerType{TimerType::ONE_SHOT};
 MATCHER_P(WebAudioConfigMatcher, config, "")
 {


### PR DESCRIPTION
Summary: Limit samples queue size for WebAudio
Type: Fix
Test Plan: UT/ CT, Fullstack
Jira: ENTDAI-513