### PR TITLE
Add support for pending video mute if sink is not present

### DIFF
--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -215,11 +215,11 @@ static gboolean rialto_mse_video_sink_event(GstPad *pad, GstObject *parent, GstE
                         GST_ERROR_OBJECT(sink, "Could not set syncmode-streaming");
                     }
                 }
-                if (priv->showVideoWindowQueued)
+                if (priv->videoMuteQueued)
                 {
                     GST_DEBUG_OBJECT(sink, "Set queued show-video-window");
-                    priv->showVideoWindowQueued = false;
-                    client->setMute(priv->showVideoWindow, basePriv->m_sourceId);
+                    priv->videoMuteQueued = false;
+                    client->setMute(priv->videoMute, basePriv->m_sourceId);
                 }
             }
         }
@@ -431,18 +431,18 @@ static void rialto_mse_video_sink_set_property(GObject *object, guint propId, co
     }
     case PROP_SHOW_VIDEO_WINDOW:
     {
-        bool showVideoWindow = (g_value_get_boolean(value) == TRUE);
+        bool videoMute = (g_value_get_boolean(value) == FALSE);
         std::unique_lock lock{priv->propertyMutex};
-        priv->showVideoWindow = showVideoWindow;
-        if (!client)
+        priv->videoMute = videoMute;
+        if (!client || !basePriv->m_sourceAttached)
         {
             GST_DEBUG_OBJECT(sink, "Show video window setting enqueued");
-            priv->showVideoWindowQueued = true;
+            priv->videoMuteQueued = true;
         }
         else
         {
             lock.unlock();
-            client->setMute(showVideoWindow, basePriv->m_sourceId);
+            client->setMute(videoMute, basePriv->m_sourceId);
         }
         break;
     }

--- a/source/RialtoGStreamerMSEVideoSinkPrivate.h
+++ b/source/RialtoGStreamerMSEVideoSinkPrivate.h
@@ -40,8 +40,8 @@ struct _RialtoMSEVideoSinkPrivate
     bool immediateOutputQueued{false};
     bool syncmodeStreaming{false};
     bool syncmodeStreamingQueued{false};
-    bool showVideoWindow{true};
-    bool showVideoWindowQueued{false};
+    bool videoMute{false};
+    bool videoMuteQueued{false};
     // END of variables locked by propertyMutex
 };
 

--- a/tests/ut/GstreamerMseVideoSinkTests.cpp
+++ b/tests/ut/GstreamerMseVideoSinkTests.cpp
@@ -225,8 +225,9 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldSetShowVideoWindow)
 {
     TestContext textContext = createPipelineWithVideoSinkAndSetToPaused();
 
-    constexpr gboolean kShowVideoWindow{TRUE};
-    EXPECT_CALL(m_mediaPipelineMock, setMute(textContext.m_sourceId, kShowVideoWindow)).WillOnce(Return(true));
+    constexpr gboolean kShowVideoWindow{FALSE};
+    EXPECT_CALL(m_mediaPipelineMock, setMute(textContext.m_sourceId, !(static_cast<bool>(kShowVideoWindow))))
+        .WillOnce(Return(true));
     g_object_set(textContext.m_sink, "show-video-window", kShowVideoWindow, nullptr);
 
     setNullState(textContext.m_pipeline, textContext.m_sourceId);
@@ -245,7 +246,7 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldSetCachedShowVideoWindow)
     const int32_t kSourceId{videoSourceWillBeAttached(createVideoMediaSource())};
     allSourcesWillBeAttached();
 
-    EXPECT_CALL(m_mediaPipelineMock, setMute(kSourceId, kShowVideoWindow)).WillOnce(Return(true));
+    EXPECT_CALL(m_mediaPipelineMock, setMute(kSourceId, !(static_cast<bool>(kShowVideoWindow)))).WillOnce(Return(true));
 
     GstCaps *caps{createVideoCaps()};
     setCaps(videoSink, caps);


### PR DESCRIPTION
Summary: Add support for pending video mute if sink is not present
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: VPLAY-10045