### PR TITLE
Add MP3 support to rialto

### DIFF
--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -32,6 +32,7 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
 {
     static const std::unordered_map<std::string, std::vector<std::string>> kMimeToCaps =
         {{"audio/mp4", {"audio/mpeg, mpegversion=1", "audio/mpeg, mpegversion=2", "audio/mpeg, mpegversion=4"}},
+         {"audio/mp3", {"audio/mpeg, mpegversion=1", "audio/mpeg, mpegversion=2"}},
          {"audio/aac", {"audio/mpeg, mpegversion=2", "audio/mpeg, mpegversion=4"}},
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},

--- a/source/PullModeAudioPlaybackDelegate.cpp
+++ b/source/PullModeAudioPlaybackDelegate.cpp
@@ -572,7 +572,18 @@ PullModeAudioPlaybackDelegate::createMediaSource(GstCaps *caps) const
 
             if (g_str_has_prefix(structName, "audio/mpeg"))
             {
-                mimeType = "audio/mp4";
+                gint mpegversion{0};
+                gint layer{0};
+                gst_structure_get_int(structure, "mpegversion", &mpegversion);
+                gst_structure_get_int(structure, "layer", &layer);
+                if (1 == mpegversion && 3 == layer)
+                {
+                    mimeType = "audio/mp3";
+                }
+                else
+                {
+                    mimeType = "audio/mp4";
+                }
             }
             else
             {

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -135,6 +135,26 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithMpeg)
     gst_object_unref(pipeline);
 }
 
+TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithMp3)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const firebolt::rialto::IMediaPipeline::MediaSourceAudio kExpectedSource{"audio/mp3", kHasDrm, kAudioConfig};
+    const int32_t kSourceId{audioSourceWillBeAttached(kExpectedSource)};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 1, "layer", G_TYPE_INT, 3, "channels",
+                                      G_TYPE_INT, kChannels, "rate", G_TYPE_INT, kRate, nullptr)};
+    setCaps(audioSink, caps);
+
+    setNullState(pipeline, kSourceId);
+
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
 TEST_F(GstreamerMseAudioSinkTests, ShouldAttachSourceWithEac3)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();

--- a/tests/ut/RialtoGstTest.cpp
+++ b/tests/ut/RialtoGstTest.cpp
@@ -49,8 +49,8 @@ constexpr bool kHasDrm{true};
 constexpr int kChannels{1};
 constexpr int kRate{48000};
 const firebolt::rialto::AudioConfig kAudioConfig{kChannels, kRate, {}};
-const std::vector<std::string> kSupportedAudioMimeTypes{"audio/mp4",   "audio/aac",   "audio/x-eac3", "audio/x-opus",
-                                                        "audio/b-wav", "audio/x-raw", "audio/x-flac"};
+const std::vector<std::string> kSupportedAudioMimeTypes{"audio/mp4",    "audio/mp3",   "audio/aac",   "audio/x-eac3",
+                                                        "audio/x-opus", "audio/b-wav", "audio/x-raw", "audio/x-flac"};
 const std::vector<std::string> kSupportedVideoMimeTypes{"video/h264", "video/h265", "video/x-av1", "video/x-vp9",
                                                         "video/unsupported"};
 const std::vector<std::string> kSupportedSubtitlesMimeTypes{"text/vtt", "text/ttml"};


### PR DESCRIPTION
Summary: Add MP3 support to rialto
Type: Fix
Test Plan: UT/ CT, Fullstack
Jira: ENTDAI-748