### PR TITLE
IsVideoMaster function moved to IMediaPipelineCapabilities interface

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -900,18 +900,6 @@ bool GStreamerMSEMediaPlayerClient::switchSource(const std::unique_ptr<firebolt:
     return result;
 }
 
-bool GStreamerMSEMediaPlayerClient::isVideoMaster(bool &isVideoMaster)
-{
-    if (!m_clientBackend)
-    {
-        return false;
-    }
-
-    bool result = false;
-    m_backendQueue->callInEventLoop([&]() { result = m_clientBackend->isVideoMaster(isVideoMaster); });
-    return result;
-}
-
 bool GStreamerMSEMediaPlayerClient::checkIfAllAttachedSourcesInStates(const std::vector<ClientState> &states)
 {
     return std::all_of(m_attachedSources.begin(), m_attachedSources.end(), [states](const auto &source)

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -316,7 +316,6 @@ public:
     void setUseBuffering(bool useBuffering);
     bool getUseBuffering();
     bool switchSource(const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> &source);
-    bool isVideoMaster(bool &isVideoMaster);
 
 private:
     bool areAllStreamsAttached();

--- a/source/IPlaybackDelegate.h
+++ b/source/IPlaybackDelegate.h
@@ -56,7 +56,6 @@ public:
         ImmediateOutput,
         SyncmodeStreaming,
         ShowVideoWindow,
-        IsMaster,
 
         // PullModeSubtitlePlaybackDelegate Properties
         TextTrackIdentifier,

--- a/source/MediaPlayerClientBackend.h
+++ b/source/MediaPlayerClientBackend.h
@@ -176,8 +176,6 @@ public:
         return m_mediaPlayerBackend->switchSource(source);
     }
 
-    bool isVideoMaster(bool &isVideoMaster) override { return m_mediaPlayerBackend->isVideoMaster(isVideoMaster); }
-
 private:
     std::unique_ptr<IMediaPipeline> m_mediaPlayerBackend;
 };

--- a/source/MediaPlayerClientBackendInterface.h
+++ b/source/MediaPlayerClientBackendInterface.h
@@ -71,6 +71,5 @@ public:
     virtual bool setUseBuffering(bool useBuffering) = 0;
     virtual bool getUseBuffering(bool &useBuffering) = 0;
     virtual bool switchSource(const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> &source) = 0;
-    virtual bool isVideoMaster(bool &isVideoMaster) = 0;
 };
 } // namespace firebolt::rialto::client

--- a/source/PullModeVideoPlaybackDelegate.cpp
+++ b/source/PullModeVideoPlaybackDelegate.cpp
@@ -201,17 +201,6 @@ void PullModeVideoPlaybackDelegate::getProperty(const Property &type, GValue *va
         }
         break;
     }
-    case Property::IsMaster:
-    {
-        bool isMaster{true};
-        auto client = m_mediaPlayerManager.getMediaPlayerClient();
-        if (!client || !client->isVideoMaster(isMaster))
-        {
-            GST_ERROR_OBJECT(m_sink, "Could not check if video is master. Setting default value.");
-        }
-        g_value_set_boolean(value, isMaster);
-        break;
-    }
     default:
     {
         PullModePlaybackDelegate::getProperty(type, value);

--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -125,11 +125,6 @@ static void rialto_mse_video_sink_get_property(GObject *object, guint propId, GV
         {
             g_value_set_boolean(value, isMaster);
         }
-        else
-        {
-            rialto_mse_base_sink_handle_get_property(RIALTO_MSE_BASE_SINK(object),
-                                                     IPlaybackDelegate::Property::IsMaster, value);
-        }
         break;
     }
     default:

--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -118,8 +118,18 @@ static void rialto_mse_video_sink_get_property(GObject *object, guint propId, GV
     case PROP_IS_MASTER:
     {
         g_value_set_boolean(value, TRUE); // Set default value
-        rialto_mse_base_sink_handle_get_property(RIALTO_MSE_BASE_SINK(object), IPlaybackDelegate::Property::IsMaster,
-                                                 value);
+        std::unique_ptr<firebolt::rialto::IMediaPipelineCapabilities> mediaPlayerCapabilities =
+            firebolt::rialto::IMediaPipelineCapabilitiesFactory::createFactory()->createMediaPipelineCapabilities();
+        bool isMaster{false};
+        if (mediaPlayerCapabilities && mediaPlayerCapabilities->isVideoMaster(isMaster))
+        {
+            g_value_set_boolean(value, isMaster);
+        }
+        else
+        {
+            rialto_mse_base_sink_handle_get_property(RIALTO_MSE_BASE_SINK(object),
+                                                     IPlaybackDelegate::Property::IsMaster, value);
+        }
         break;
     }
     default:

--- a/tests/mocks/MediaPipelineCapabilitiesMock.h
+++ b/tests/mocks/MediaPipelineCapabilitiesMock.h
@@ -37,6 +37,7 @@ public:
     MOCK_METHOD(bool, isMimeTypeSupported, (const std::string &mimeType), (override));
     MOCK_METHOD(std::vector<std::string>, getSupportedProperties,
                 (MediaSourceType mediaType, const std::vector<std::string> &propertyNames), (override));
+    MOCK_METHOD(bool, isVideoMaster, (bool &isVideoMaster), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -77,7 +77,6 @@ public:
     MOCK_METHOD(bool, setUseBuffering, (bool useBuffering), (override));
     MOCK_METHOD(bool, getUseBuffering, (bool &useBuffering), (override));
     MOCK_METHOD(bool, switchSource, (const std::unique_ptr<MediaSource> &source), (override));
-    MOCK_METHOD(bool, isVideoMaster, (bool &isVideoMaster), (override));
 };
 } // namespace firebolt::rialto
 

--- a/tests/mocks/MediaPlayerClientBackendMock.h
+++ b/tests/mocks/MediaPlayerClientBackendMock.h
@@ -77,7 +77,6 @@ public:
     MOCK_METHOD(bool, getUseBuffering, (bool &useBuffering), (override));
     MOCK_METHOD(bool, switchSource, (const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSource> &source),
                 (override));
-    MOCK_METHOD(bool, isVideoMaster, (bool &isVideoMaster), (override));
 };
 } // namespace firebolt::rialto::client
 

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -1621,31 +1621,3 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSwitchSource)
     EXPECT_CALL(*m_mediaPlayerClientBackendMock, switchSource(PtrMatcher(mediaSource.get()))).WillOnce(Return(true));
     m_sut->switchSource(mediaSource);
 }
-
-TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetIsVideoMaster)
-{
-    constexpr bool kIsVideoMaster{true};
-    expectCallInEventLoop();
-    EXPECT_CALL(*m_mediaPlayerClientBackendMock, isVideoMaster(_))
-        .WillOnce(DoAll(SetArgReferee<0>(kIsVideoMaster), Return(true)));
-
-    bool isVideoMaster = false;
-    EXPECT_TRUE(m_sut->isVideoMaster(isVideoMaster));
-    EXPECT_EQ(isVideoMaster, kIsVideoMaster);
-}
-
-TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotGetIsVideoMasterIfNoClientBackend)
-{
-    // Need to create a new message queue as it has been moved
-    m_messageQueue = std::make_unique<StrictMock<MessageQueueMock>>();
-    StrictMock<MessageQueueMock> &messageQueueMock{*m_messageQueue};
-
-    EXPECT_CALL(*m_messageQueueFactoryMock, createMessageQueue()).WillOnce(Return(ByMove(std::move(m_messageQueue))));
-    EXPECT_CALL(messageQueueMock, start());
-    EXPECT_CALL(messageQueueMock, stop());
-    m_sut = std::make_shared<GStreamerMSEMediaPlayerClient>(m_messageQueueFactoryMock, nullptr, kMaxVideoWidth,
-                                                            kMaxVideoHeight);
-
-    bool isVideoMaster = false;
-    EXPECT_FALSE(m_sut->isVideoMaster(isVideoMaster));
-}

--- a/tests/ut/GstreamerMseVideoSinkTests.cpp
+++ b/tests/ut/GstreamerMseVideoSinkTests.cpp
@@ -659,42 +659,6 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldNotRenderFrameTwice)
     gst_object_unref(textContext.m_pipeline);
 }
 
-TEST_F(GstreamerMseVideoSinkTests, ShouldFailToGetIsMasterPropertyFromMediaPipelineWhenPipelineIsBelowPausedState)
-{
-    RialtoMSEBaseSink *videoSink = createVideoSink();
-
-    std::shared_ptr<StrictMock<MediaPipelineCapabilitiesFactoryMock>> capabilitiesFactoryMock{
-        std::dynamic_pointer_cast<StrictMock<MediaPipelineCapabilitiesFactoryMock>>(
-            IMediaPipelineCapabilitiesFactory::createFactory())};
-    ASSERT_TRUE(capabilitiesFactoryMock);
-    EXPECT_CALL(*capabilitiesFactoryMock, createMediaPipelineCapabilities()).WillOnce(Return(nullptr));
-    gboolean isMaster{FALSE};
-    g_object_get(videoSink, "is-master", &isMaster, nullptr);
-    EXPECT_EQ(isMaster, TRUE); // Default value should be returned.
-
-    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
-    gst_object_unref(videoSink);
-}
-
-TEST_F(GstreamerMseVideoSinkTests, ShouldGetIsMasterPropertyFromMediaPipeline)
-{
-    constexpr bool kIsMaster{false};
-    TestContext textContext = createPipelineWithVideoSinkAndSetToPaused();
-
-    std::shared_ptr<StrictMock<MediaPipelineCapabilitiesFactoryMock>> capabilitiesFactoryMock{
-        std::dynamic_pointer_cast<StrictMock<MediaPipelineCapabilitiesFactoryMock>>(
-            IMediaPipelineCapabilitiesFactory::createFactory())};
-    ASSERT_TRUE(capabilitiesFactoryMock);
-    EXPECT_CALL(*capabilitiesFactoryMock, createMediaPipelineCapabilities()).WillOnce(Return(nullptr));
-    EXPECT_CALL(m_mediaPipelineMock, isVideoMaster(_)).WillOnce(DoAll(SetArgReferee<0>(kIsMaster), Return(true)));
-    gboolean isMaster{TRUE};
-    g_object_get(textContext.m_sink, "is-master", &isMaster, nullptr);
-    EXPECT_EQ(static_cast<bool>(isMaster), kIsMaster);
-
-    setNullState(textContext.m_pipeline, textContext.m_sourceId);
-    gst_object_unref(textContext.m_pipeline);
-}
-
 TEST_F(GstreamerMseVideoSinkTests, ShouldGetIsMasterPropertyFromMediaPipelineCapabilities)
 {
     constexpr bool kIsMaster{false};

--- a/tests/ut/MediaPlayerClientBackendTests.cpp
+++ b/tests/ut/MediaPlayerClientBackendTests.cpp
@@ -337,14 +337,3 @@ TEST_F(MediaPlayerClientBackendTests, ShouldSwitchSource)
     ASSERT_TRUE(m_sut.isMediaPlayerBackendCreated());
     EXPECT_TRUE(m_sut.switchSource(mediaSourceAudio));
 }
-
-TEST_F(MediaPlayerClientBackendTests, ShouldGetIsVideoMaster)
-{
-    bool isVideoMaster{false};
-    constexpr bool kIsVideoMaster{true};
-    EXPECT_CALL(*m_mediaPipelineMock, isVideoMaster(_)).WillOnce(DoAll(SetArgReferee<0>(kIsVideoMaster), Return(true)));
-    initializeMediaPipeline();
-    ASSERT_TRUE(m_sut.isMediaPlayerBackendCreated());
-    EXPECT_TRUE(m_sut.isVideoMaster(isVideoMaster));
-    EXPECT_EQ(kIsVideoMaster, isVideoMaster);
-}


### PR DESCRIPTION
Summary: IsVideoMaster function moved to IMediaPipelineCapabilities interface
Type: Fix
Test Plan: UT/ CT, Fullstack
Jira: VPLAY-8941