### PR TITLE
RDKEMW-16798: Add parsed=true to MP3 sink pad caps to fix seek support.

### DIFF
--- a/source/GStreamerMSEUtils.cpp
+++ b/source/GStreamerMSEUtils.cpp
@@ -32,7 +32,7 @@ void rialto_mse_sink_setup_supported_caps(GstElementClass *elementClass,
 {
     static const std::unordered_map<std::string, std::vector<std::string>> kMimeToCaps =
         {{"audio/mp4", {"audio/mpeg, mpegversion=1", "audio/mpeg, mpegversion=2", "audio/mpeg, mpegversion=4"}},
-         {"audio/mp3", {"audio/mpeg, mpegversion=1", "audio/mpeg, mpegversion=2"}},
+         {"audio/mp3", {"audio/mpeg, mpegversion=1, parsed=(boolean)true", "audio/mpeg, mpegversion=2, parsed=(boolean)true"}},
          {"audio/aac", {"audio/mpeg, mpegversion=2", "audio/mpeg, mpegversion=4"}},
          {"audio/x-eac3", {"audio/x-ac3", "audio/x-eac3"}},
          {"audio/x-opus", {"audio/x-opus"}},


### PR DESCRIPTION
After generating gstreamer graphs with and without rialto we observed that in rialto pipeline there is missing component for mp3 parsing(GstMpegAudioParse). When webkit sends GST_ELEMENT_QUERY_DURATION it fails in rialto with error message "RialtoServer[6219]:  WRN: SRV: < T:8719 M:GstGenericPlayer.cpp F:getPosition L:1252 > Failed to query position*. This is happening because mp3 is not parsed and duration is unknown.

Adding parsed=(boolean)true to the MP3 caps forces decodebin to insert mpegaudioparse, which reads headers and frame counts to determine total duration, enabling seeking.