### PR TITLE
Bringing back support for "queued-frames" and "report-decode-errors" properties

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -181,6 +181,19 @@ bool GStreamerMSEMediaPlayerClient::setImmediateOutput(int32_t sourceId, bool im
     return status;
 }
 
+bool GStreamerMSEMediaPlayerClient::setReportDecodeErrors(int32_t sourceId, bool reportDecodeErrors)
+{
+    if (!m_clientBackend)
+    {
+        return false;
+    }
+
+    bool status{false};
+    m_backendQueue->callInEventLoop([&]()
+                                    { status = m_clientBackend->setReportDecodeErrors(sourceId, reportDecodeErrors); });
+    return status;
+}
+
 bool GStreamerMSEMediaPlayerClient::getImmediateOutput(int32_t sourceId, bool &immediateOutput)
 {
     if (!m_clientBackend)
@@ -190,6 +203,18 @@ bool GStreamerMSEMediaPlayerClient::getImmediateOutput(int32_t sourceId, bool &i
 
     bool status{false};
     m_backendQueue->callInEventLoop([&]() { status = m_clientBackend->getImmediateOutput(sourceId, immediateOutput); });
+    return status;
+}
+
+bool GStreamerMSEMediaPlayerClient::getQueuedFrames(int32_t sourceId, uint32_t &queuedFrames)
+{
+    if (!m_clientBackend)
+    {
+        return false;
+    }
+
+    bool status{false};
+    m_backendQueue->callInEventLoop([&]() { status = m_clientBackend->getQueuedFrames(sourceId, queuedFrames); });
     return status;
 }
 

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -269,7 +269,9 @@ public:
 
     int64_t getPosition(int32_t sourceId);
     bool setImmediateOutput(int32_t sourceId, bool immediateOutput);
+    bool setReportDecodeErrors(int32_t sourceId, bool reportDecodeErrors);
     bool getImmediateOutput(int32_t sourceId, bool &immediateOutput);
+    bool getQueuedFrames(int32_t sourceId, uint32_t &queuedFrames);
     bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames);
 
     firebolt::rialto::AddSegmentStatus

--- a/source/IPlaybackDelegate.h
+++ b/source/IPlaybackDelegate.h
@@ -59,6 +59,8 @@ public:
         ImmediateOutput,
         SyncmodeStreaming,
         ShowVideoWindow,
+        ReportDecodeErrors,
+        QueuedFrames,
 
         // PullModeSubtitlePlaybackDelegate Properties
         TextTrackIdentifier,

--- a/source/MediaPlayerClientBackend.h
+++ b/source/MediaPlayerClientBackend.h
@@ -90,9 +90,19 @@ public:
         return m_mediaPlayerBackend->setImmediateOutput(sourceId, immediateOutput);
     }
 
+    bool setReportDecodeErrors(int32_t sourceId, bool reportDecodeErrors) override
+    {
+        return m_mediaPlayerBackend->setReportDecodeErrors(sourceId, reportDecodeErrors);
+    }
+
     bool getImmediateOutput(int32_t sourceId, bool &immediateOutput) override
     {
         return m_mediaPlayerBackend->getImmediateOutput(sourceId, immediateOutput);
+    }
+
+    bool getQueuedFrames(int32_t sourceId, uint32_t &queuedFrames) override
+    {
+        return m_mediaPlayerBackend->getQueuedFrames(sourceId, queuedFrames);
     }
 
     bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames) override

--- a/source/MediaPlayerClientBackendInterface.h
+++ b/source/MediaPlayerClientBackendInterface.h
@@ -47,7 +47,9 @@ public:
                const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment) = 0;
     virtual bool getPosition(int64_t &position) = 0;
     virtual bool setImmediateOutput(int32_t sourceId, bool immediateOutput) = 0;
+    virtual bool setReportDecodeErrors(int32_t sourceId, bool reportDecodeErrors) = 0;
     virtual bool getImmediateOutput(int32_t sourceId, bool &immediateOutput) = 0;
+    virtual bool getQueuedFrames(int32_t sourceId, uint32_t &queuedFrames) = 0;
     virtual bool getStats(int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames) = 0;
     virtual bool renderFrame() = 0;
     virtual bool setVolume(double targetVolume, uint32_t volumeDuration, EaseType easeType) = 0;

--- a/source/PullModeVideoPlaybackDelegate.cpp
+++ b/source/PullModeVideoPlaybackDelegate.cpp
@@ -105,6 +105,15 @@ gboolean PullModeVideoPlaybackDelegate::handleEvent(GstPad *pad, GstObject *pare
                         GST_ERROR_OBJECT(m_sink, "Could not set immediate-output");
                     }
                 }
+                if (m_reportDecodeErrorsQueued)
+                {
+                    GST_DEBUG_OBJECT(m_sink, "Set queued report-decode-errors");
+                    m_reportDecodeErrorsQueued = false;
+                    if (!client->setReportDecodeErrors(m_sourceId, m_reportDecodeErrors))
+                    {
+                        GST_ERROR_OBJECT(m_sink, "Could not set report-decode-errors");
+                    }
+                }
                 if (m_syncmodeStreamingQueued)
                 {
                     GST_DEBUG_OBJECT(m_sink, "Set queued syncmode-streaming");
@@ -173,6 +182,28 @@ void PullModeVideoPlaybackDelegate::getProperty(const Property &type, GValue *va
     case Property::FrameStepOnPreroll:
     {
         g_value_set_boolean(value, m_stepOnPrerollEnabled);
+        break;
+    }
+    case Property::QueuedFrames:
+    {
+        uint32_t queuedFrames = 0;
+
+        std::unique_lock lock{m_propertyMutex};
+        auto client = m_mediaPlayerManager.getMediaPlayerClient();
+        if (!client)
+        {
+            GST_DEBUG_OBJECT(m_sink, "Getting queued frames: no client, returning 0");
+        }
+        else
+        {
+            lock.unlock();
+            if (!client->getQueuedFrames(m_sourceId, queuedFrames))
+            {
+                GST_ERROR_OBJECT(m_sink, "Could not get queued frames");
+            }
+        }
+
+        g_value_set_uint(value, queuedFrames);
         break;
     }
     case Property::ImmediateOutput:
@@ -252,6 +283,26 @@ void PullModeVideoPlaybackDelegate::setProperty(const Property &type, const GVal
             client->renderFrame(m_sourceId);
         }
         m_stepOnPrerollEnabled = stepOnPrerollEnabled;
+        break;
+    }
+    case Property::ReportDecodeErrors:
+    {
+        bool reportDecodeErrors = g_value_get_boolean(value);
+        std::unique_lock lock{m_propertyMutex};
+        m_reportDecodeErrors = reportDecodeErrors;
+        if (!client)
+        {
+            GST_DEBUG_OBJECT(m_sink, "Report decode errors setting enqueued");
+            m_reportDecodeErrorsQueued = true;
+        }
+        else
+        {
+            lock.unlock();
+            if (!client->setReportDecodeErrors(m_sourceId, reportDecodeErrors))
+            {
+                GST_ERROR_OBJECT(m_sink, "Could not set report-decode-errors");
+            }
+        }
         break;
     }
     case Property::ImmediateOutput:

--- a/source/PullModeVideoPlaybackDelegate.h
+++ b/source/PullModeVideoPlaybackDelegate.h
@@ -49,6 +49,8 @@ private:
     // immediate output properties
     bool m_immediateOutput{false};
     bool m_immediateOutputQueued{false};
+    bool m_reportDecodeErrors{false};
+    bool m_reportDecodeErrorsQueued{false};
     bool m_syncmodeStreaming{false};
     bool m_syncmodeStreamingQueued{false};
     bool m_videoMute{false};

--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -50,6 +50,8 @@ enum
     PROP_SYNCMODE_STREAMING,
     PROP_SHOW_VIDEO_WINDOW,
     PROP_IS_MASTER,
+    PROP_REPORT_DECODE_ERRORS,
+    PROP_QUEUED_FRAMES,
     PROP_LAST
 };
 
@@ -108,6 +110,13 @@ static void rialto_mse_video_sink_get_property(GObject *object, guint propId, GV
                                                  IPlaybackDelegate::Property::FrameStepOnPreroll, value);
         break;
     }
+    case PROP_QUEUED_FRAMES:
+    {
+        g_value_set_uint(value, 0); // Set default value
+        rialto_mse_base_sink_handle_get_property(RIALTO_MSE_BASE_SINK(object),
+                                                 IPlaybackDelegate::Property::QueuedFrames, value);
+        break;
+    }
     case PROP_IMMEDIATE_OUTPUT:
     {
         g_value_set_boolean(value, FALSE); // Set default value
@@ -157,6 +166,12 @@ static void rialto_mse_video_sink_set_property(GObject *object, guint propId, co
     {
         rialto_mse_base_sink_handle_set_property(RIALTO_MSE_BASE_SINK(object),
                                                  IPlaybackDelegate::Property::FrameStepOnPreroll, value);
+        break;
+    }
+    case PROP_REPORT_DECODE_ERRORS:
+    {
+        rialto_mse_base_sink_handle_set_property(RIALTO_MSE_BASE_SINK(object),
+                                                 IPlaybackDelegate::Property::ReportDecodeErrors, value);
         break;
     }
     case PROP_IMMEDIATE_OUTPUT:
@@ -231,6 +246,14 @@ static void rialto_mse_video_sink_class_init(RialtoMSEVideoSinkClass *klass)
                                     g_param_spec_boolean("frame-step-on-preroll", "frame step on preroll",
                                                          "allow frame stepping on preroll into pause", FALSE,
                                                          G_PARAM_READWRITE));
+    g_object_class_install_property(gobjectClass, PROP_REPORT_DECODE_ERRORS,
+                                    g_param_spec_boolean("report-decode-errors", "Report decode errors",
+                                                         "Enable reporting of decode errors", FALSE, G_PARAM_WRITABLE));
+
+    g_object_class_install_property(gobjectClass, PROP_QUEUED_FRAMES,
+                                    g_param_spec_uint("queued-frames", "Queued frames",
+                                                      "Number of frames currently queued in decoder", 0, G_MAXUINT, 0,
+                                                      G_PARAM_READABLE));
     g_object_class_install_property(gobjectClass, PROP_IS_MASTER,
                                     g_param_spec_boolean("is-master", "is master",
                                                          "Checks if the platform is video master", TRUE,

--- a/tests/mocks/MediaPipelineMock.h
+++ b/tests/mocks/MediaPipelineMock.h
@@ -46,8 +46,10 @@ public:
     MOCK_METHOD(bool, setPlaybackRate, (double rate), (override));
     MOCK_METHOD(bool, setPosition, (int64_t position), (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
+    MOCK_METHOD(bool, setReportDecodeErrors, (int32_t sourceId, bool reportDecodeErrors), (override));
     MOCK_METHOD(bool, setImmediateOutput, (int32_t sourceId, bool immediateOutput), (override));
     MOCK_METHOD(bool, getImmediateOutput, (int32_t sourceId, bool &immediateOutput), (override));
+    MOCK_METHOD(bool, getQueuedFrames, (int32_t sourceId, uint32_t &queuedFrames), (override));
     MOCK_METHOD(bool, getStats, (int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames), (override));
     MOCK_METHOD(bool, setVideoWindow, (uint32_t x, uint32_t y, uint32_t width, uint32_t height), (override));
     MOCK_METHOD(bool, haveData, (MediaSourceStatus status, uint32_t needDataRequestId), (override));

--- a/tests/mocks/MediaPlayerClientBackendMock.h
+++ b/tests/mocks/MediaPlayerClientBackendMock.h
@@ -48,8 +48,10 @@ public:
                  const std::unique_ptr<firebolt::rialto::IMediaPipeline::MediaSegment> &mediaSegment),
                 (override));
     MOCK_METHOD(bool, getPosition, (int64_t & position), (override));
+    MOCK_METHOD(bool, setReportDecodeErrors, (int32_t sourceId, bool reportDecodeErrors), (override));
     MOCK_METHOD(bool, setImmediateOutput, (int32_t sourceId, bool immediateOutput), (override));
     MOCK_METHOD(bool, getImmediateOutput, (int32_t sourceId, bool &immediateOutput), (override));
+    MOCK_METHOD(bool, getQueuedFrames, (int32_t sourceId, uint32_t &queuedFrames), (override));
     MOCK_METHOD(bool, getStats, (int32_t sourceId, uint64_t &renderedFrames, uint64_t &droppedFrames), (override));
     MOCK_METHOD(bool, renderFrame, (), (override));
     MOCK_METHOD(bool, setVolume, (double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType type),

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -59,6 +59,8 @@ constexpr uint32_t kDuration{30};
 constexpr int64_t kDiscontinuityGap{1};
 constexpr bool kAudioAac{false};
 const std::string kTextTrackIdentifier{"TextTrackId"};
+constexpr bool kReportDecodeErrors{true};
+constexpr uint32_t kQueuedFrames{12};
 constexpr bool kImmediateOutput{true};
 constexpr bool kLowLatency{true};
 constexpr bool kSync{true};
@@ -1297,6 +1299,37 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetMute)
     gst_object_unref(audioSink);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetReportDecodeErrors)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    bufferPullerWillBeCreated();
+    const int32_t kVideoSourceId = attachSource(videoSink, firebolt::rialto::MediaSourceType::VIDEO);
+
+    expectCallInEventLoop();
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, setReportDecodeErrors(kVideoSourceId, kReportDecodeErrors))
+        .WillOnce(Return(true));
+    EXPECT_TRUE(m_sut->setReportDecodeErrors(kVideoSourceId, kReportDecodeErrors));
+
+    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
+    gst_object_unref(videoSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSetReportDecodeErrorsIfNoClientBackend)
+{
+    // Need to create a new message queue as it has been moved
+    m_messageQueue = std::make_unique<StrictMock<MessageQueueMock>>();
+    StrictMock<MessageQueueMock> &messageQueueMock{*m_messageQueue};
+
+    EXPECT_CALL(*m_messageQueueFactoryMock, createMessageQueue()).WillOnce(Return(ByMove(std::move(m_messageQueue))));
+    EXPECT_CALL(messageQueueMock, start());
+    EXPECT_CALL(messageQueueMock, stop());
+    m_sut = std::make_shared<GStreamerMSEMediaPlayerClient>(m_messageQueueFactoryMock, nullptr, kMaxVideoWidth,
+                                                            kMaxVideoHeight);
+
+    const int32_t kVideoSourceId = 1;
+    EXPECT_FALSE(m_sut->setReportDecodeErrors(kVideoSourceId, kReportDecodeErrors));
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetImmediateOutput)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();
@@ -1360,6 +1393,41 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotGetImmediateOutputIfNoClient
     const int32_t kAudioSourceId = 1;
     bool immediateOutput = false;
     EXPECT_FALSE(m_sut->getImmediateOutput(kAudioSourceId, immediateOutput));
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetQueuedFrames)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    bufferPullerWillBeCreated();
+    const int32_t kVideoSourceId = attachSource(videoSink, firebolt::rialto::MediaSourceType::VIDEO);
+
+    expectCallInEventLoop();
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, getQueuedFrames(kVideoSourceId, _))
+        .WillOnce(DoAll(SetArgReferee<1>(kQueuedFrames), Return(true)));
+
+    uint32_t queuedFrames = 0;
+    EXPECT_TRUE(m_sut->getQueuedFrames(kVideoSourceId, queuedFrames));
+    EXPECT_EQ(queuedFrames, kQueuedFrames);
+
+    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
+    gst_object_unref(videoSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotGetQueuedFramesIfNoClientBackend)
+{
+    // Need to create a new message queue as it has been moved
+    m_messageQueue = std::make_unique<StrictMock<MessageQueueMock>>();
+    StrictMock<MessageQueueMock> &messageQueueMock{*m_messageQueue};
+
+    EXPECT_CALL(*m_messageQueueFactoryMock, createMessageQueue()).WillOnce(Return(ByMove(std::move(m_messageQueue))));
+    EXPECT_CALL(messageQueueMock, start());
+    EXPECT_CALL(messageQueueMock, stop());
+    m_sut = std::make_shared<GStreamerMSEMediaPlayerClient>(m_messageQueueFactoryMock, nullptr, kMaxVideoWidth,
+                                                            kMaxVideoHeight);
+
+    const int32_t kVideoSourceId = 1;
+    uint32_t queuedFrames = 0;
+    EXPECT_FALSE(m_sut->getQueuedFrames(kVideoSourceId, queuedFrames));
 }
 
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetLowLatency)

--- a/tests/ut/GstreamerMseVideoSinkTests.cpp
+++ b/tests/ut/GstreamerMseVideoSinkTests.cpp
@@ -165,6 +165,80 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldSetImmediateOutputProperty)
     gst_object_unref(pipeline);
 }
 
+TEST_F(GstreamerMseVideoSinkTests, ShouldSetQueuedReportDecodeErrors)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+
+    // Queue an report-decode-errors request
+    EXPECT_CALL(m_mediaPipelineMock, setReportDecodeErrors(_, true)).WillOnce(Return(true));
+    g_object_set(videoSink, "report-decode-errors", TRUE, nullptr);
+
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createDefaultMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createDefaultCaps()};
+    setCaps(videoSink, caps);
+
+    setNullState(pipeline, kSourceId);
+
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldSetReportDecodeErrorsProperty)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createVideoMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createVideoCaps()};
+    setCaps(videoSink, caps);
+
+    EXPECT_CALL(m_mediaPipelineMock, setReportDecodeErrors(_, _)).WillOnce(Return(true));
+    g_object_set(videoSink, "report-decode-errors", TRUE, nullptr);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldFailToSetReportDecodeErrorsPropertyDueToPipelinedFailure)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createVideoMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createVideoCaps()};
+    setCaps(videoSink, caps);
+
+    EXPECT_CALL(m_mediaPipelineMock, setReportDecodeErrors(_, _)).WillOnce(Return(false));
+    g_object_set(videoSink, "report-decode-errors", TRUE, nullptr);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldFailToSetReportDecodeErrorsProperty)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+
+    // No pipeline therefore the m_mediaPipelineMock method setReportDecodeErrors() will not be called
+    g_object_set(videoSink, "report-decode-errors", TRUE, nullptr);
+
+    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
+    gst_object_unref(videoSink);
+}
+
 TEST_F(GstreamerMseVideoSinkTests, ShouldFailToSetImmediateOutputPropertyDueToPipelinedFailure)
 {
     RialtoMSEBaseSink *videoSink = createVideoSink();
@@ -247,6 +321,62 @@ TEST_F(GstreamerMseVideoSinkTests, ShouldFailToGetImmediateOutputProperty)
     // No pipeline therefore the m_mediaPipelineMock method getImmediateOutput() will not be called
     gboolean immediateOutput;
     g_object_get(videoSink, "immediate-output", &immediateOutput, nullptr);
+
+    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
+    gst_object_unref(videoSink);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldGetQueuedFramesProperty)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createVideoMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createVideoCaps()};
+    setCaps(videoSink, caps);
+
+    EXPECT_CALL(m_mediaPipelineMock, getQueuedFrames(_, _)).WillOnce(DoAll(SetArgReferee<1>(123), Return(true)));
+    uint32_t queuedFrames{0};
+    g_object_get(videoSink, "queued-frames", &queuedFrames, nullptr);
+    EXPECT_EQ(queuedFrames, 123u);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldFailToGetQueuedFramesPropertyDueToPipelinedFailure)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+    GstElement *pipeline = createPipelineWithSink(videoSink);
+
+    setPausedState(pipeline, videoSink);
+    const int32_t kSourceId{videoSourceWillBeAttached(createVideoMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createVideoCaps()};
+    setCaps(videoSink, caps);
+
+    EXPECT_CALL(m_mediaPipelineMock, getQueuedFrames(_, _)).WillOnce(Return(false));
+    uint32_t queuedFrames{999};
+    g_object_get(videoSink, "queued-frames", &queuedFrames, nullptr);
+    EXPECT_EQ(queuedFrames, 0u);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseVideoSinkTests, ShouldFailToGetQueuedFramesProperty)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+
+    // No pipeline therefore the m_mediaPipelineMock method getQueuedFrames() will not be called
+    uint32_t queuedFrames{999};
+    g_object_get(videoSink, "queued-frames", &queuedFrames, nullptr);
 
     gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
     gst_object_unref(videoSink);


### PR DESCRIPTION
Summary: 'report-decode-errors' and 'queued-frames' properties missing from RialtoMSEVideoSink
Type: Feature
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-12692