### PR TITLE
Add first-video-frame-callback signal implementation

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -1076,9 +1076,11 @@ bool GStreamerMSEMediaPlayerClient::handleFirstFrameReceived(int sourceId)
                 result = false;
                 return;
             }
-            rialto_mse_base_handle_rialto_server_sent_first_frame_received(sourceIt->second.m_rialtoSink);
-
-            result = true;
+            if (sourceIt->second.getType() == firebolt::rialto::MediaSourceType::VIDEO)
+            {
+                rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(sourceIt->second.m_rialtoSink);
+                result = true;
+            }
         });
 
     return result;

--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -147,6 +147,11 @@ void GStreamerMSEMediaPlayerClient::notifyBufferUnderflow(int32_t sourceId)
     m_backendQueue->postMessage(std::make_shared<BufferUnderflowMessage>(sourceId, this));
 }
 
+void GStreamerMSEMediaPlayerClient::notifyFirstFrameReceived(int32_t sourceId)
+{
+    m_backendQueue->postMessage(std::make_shared<FirstFrameReceivedMessage>(sourceId, this));
+}
+
 void GStreamerMSEMediaPlayerClient::notifyPlaybackError(int32_t sourceId, firebolt::rialto::PlaybackError error)
 {
     m_backendQueue->postMessage(std::make_shared<PlaybackErrorMessage>(sourceId, error, this));
@@ -1059,6 +1064,26 @@ bool GStreamerMSEMediaPlayerClient::handleBufferUnderflow(int sourceId)
     return result;
 }
 
+bool GStreamerMSEMediaPlayerClient::handleFirstFrameReceived(int sourceId)
+{
+    bool result = false;
+    m_backendQueue->callInEventLoop(
+        [&]()
+        {
+            auto sourceIt = m_attachedSources.find(sourceId);
+            if (sourceIt == m_attachedSources.end())
+            {
+                result = false;
+                return;
+            }
+            rialto_mse_base_handle_rialto_server_sent_first_frame_received(sourceIt->second.m_rialtoSink);
+
+            result = true;
+        });
+
+    return result;
+}
+
 bool GStreamerMSEMediaPlayerClient::handlePlaybackError(int sourceId, firebolt::rialto::PlaybackError error)
 {
     bool result = false;
@@ -1279,6 +1304,19 @@ void BufferUnderflowMessage::handle()
     if (!m_player->handleBufferUnderflow(m_sourceId))
     {
         GST_ERROR("Failed to handle buffer underflow for sourceId=%d", m_sourceId);
+    }
+}
+
+FirstFrameReceivedMessage::FirstFrameReceivedMessage(int sourceId, GStreamerMSEMediaPlayerClient *player)
+    : m_sourceId(sourceId), m_player(player)
+{
+}
+
+void FirstFrameReceivedMessage::handle()
+{
+    if (!m_player->handleFirstFrameReceived(m_sourceId))
+    {
+        GST_ERROR("Failed to handle first frame received for sourceId=%d", m_sourceId);
     }
 }
 

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -184,6 +184,17 @@ private:
     GStreamerMSEMediaPlayerClient *m_player;
 };
 
+class FirstFrameReceivedMessage : public Message
+{
+public:
+    FirstFrameReceivedMessage(int sourceId, GStreamerMSEMediaPlayerClient *player);
+    void handle() override;
+
+private:
+    int m_sourceId;
+    GStreamerMSEMediaPlayerClient *m_player;
+};
+
 class PlaybackErrorMessage : public Message
 {
 public:
@@ -263,6 +274,7 @@ public:
     void notifyCancelNeedMediaData(int32_t sourceId) override;
     void notifyQos(int32_t sourceId, const firebolt::rialto::QosInfo &qosInfo) override;
     void notifyBufferUnderflow(int32_t sourceId) override;
+    void notifyFirstFrameReceived(int32_t sourceId) override;
     void notifyPlaybackError(int32_t sourceId, firebolt::rialto::PlaybackError error) override;
     void notifySourceFlushed(int32_t sourceId) override;
     void notifyPlaybackInfo(const firebolt::rialto::PlaybackInfo &playbackInfo) override;
@@ -301,6 +313,7 @@ public:
     bool requestPullBuffer(int streamId, size_t frameCount, unsigned int needDataRequestId);
     bool handleQos(int sourceId, firebolt::rialto::QosInfo qosInfo);
     bool handleBufferUnderflow(int sourceId);
+    bool handleFirstFrameReceived(int sourceId);
     bool handlePlaybackError(int sourceId, firebolt::rialto::PlaybackError error);
     void stopStreaming();
     void destroyClientBackend();

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -55,7 +55,7 @@ enum
 enum
 {
     SIGNAL_UNDERFLOW,
-    SIGNAL_FIRST_FRAME_RECEIVED,
+    SIGNAL_FIRST_VIDEO_FRAME_RECEIVED,
     SIGNAL_LAST
 };
 
@@ -260,10 +260,10 @@ void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSin
     g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_UNDERFLOW], 0, 0, nullptr);
 }
 
-void rialto_mse_base_handle_rialto_server_sent_first_frame_received(RialtoMSEBaseSink *sink)
+void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(RialtoMSEBaseSink *sink)
 {
     GST_INFO_OBJECT(sink, "Sending first frame received signal");
-    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_FRAME_RECEIVED], 0, 0, nullptr);
+    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED], 0, 0, nullptr);
 }
 
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink)
@@ -334,10 +334,10 @@ static void rialto_mse_base_sink_class_init(RialtoMSEBaseSinkClass *klass)
                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2, G_TYPE_UINT,
                                                G_TYPE_POINTER);
-    g_signals[SIGNAL_FIRST_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
-                                                          (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
-                                                          g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
-                                                          G_TYPE_UINT, G_TYPE_POINTER);
+    g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
+                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
+                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
+                                                                G_TYPE_UINT, G_TYPE_POINTER);
     g_object_class_install_property(gobjectClass, PROP_IS_SINGLE_PATH_STREAM,
                                     g_param_spec_boolean("single-path-stream", "single path stream",
                                                          "is single path stream", FALSE, GParamFlags(G_PARAM_READWRITE)));

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -55,6 +55,7 @@ enum
 enum
 {
     SIGNAL_UNDERFLOW,
+    SIGNAL_FIRST_FRAME_RECEIVED,
     SIGNAL_LAST
 };
 
@@ -259,6 +260,12 @@ void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSin
     g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_UNDERFLOW], 0, 0, nullptr);
 }
 
+void rialto_mse_base_handle_rialto_server_sent_first_frame_received(RialtoMSEBaseSink *sink)
+{
+    GST_INFO_OBJECT(sink, "Sending first frame received signal");
+    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_FRAME_RECEIVED], 0, 0, nullptr);
+}
+
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink)
 {
     GstPadTemplate *pad_template =
@@ -327,7 +334,10 @@ static void rialto_mse_base_sink_class_init(RialtoMSEBaseSinkClass *klass)
                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2, G_TYPE_UINT,
                                                G_TYPE_POINTER);
-
+    g_signals[SIGNAL_FIRST_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
+                                                          (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
+                                                          g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
+                                                          G_TYPE_UINT, G_TYPE_POINTER);
     g_object_class_install_property(gobjectClass, PROP_IS_SINGLE_PATH_STREAM,
                                     g_param_spec_boolean("single-path-stream", "single path stream",
                                                          "is single path stream", FALSE, GParamFlags(G_PARAM_READWRITE)));

--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -69,5 +69,6 @@ gboolean rialto_mse_base_sink_event(GstPad *pad, GstObject *parent, GstEvent *ev
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
+void rialto_mse_base_handle_rialto_server_sent_first_frame_received(RialtoMSEBaseSink *sink);
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -69,6 +69,6 @@ gboolean rialto_mse_base_sink_event(GstPad *pad, GstObject *parent, GstEvent *ev
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
-void rialto_mse_base_handle_rialto_server_sent_first_frame_received(RialtoMSEBaseSink *sink);
+void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(RialtoMSEBaseSink *sink);
 
 G_END_DECLS

--- a/tests/mocks/MediaPipelineClientMock.h
+++ b/tests/mocks/MediaPipelineClientMock.h
@@ -41,6 +41,7 @@ public:
     MOCK_METHOD(void, notifyCancelNeedMediaData, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyQos, (int32_t sourceId, const QosInfo &qosInfo), (override));
     MOCK_METHOD(void, notifyBufferUnderflow, (int32_t sourceId), (override));
+    MOCK_METHOD(void, notifyFirstFrameReceived, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyPlaybackError, (int32_t sourceId, PlaybackError error), (override));
     MOCK_METHOD(void, notifySourceFlushed, (int32_t sourceId), (override));
     MOCK_METHOD(void, notifyPlaybackInfo, (const PlaybackInfo &playbackInfo), (override));

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -88,6 +88,20 @@ void underflowSignalCallback(GstElement *, gpointer, guint, gpointer)
     UnderflowSignalMock::instance().callbackCalled();
 }
 
+class FirstFrameReceivedSignalMock
+{
+public:
+    static FirstFrameReceivedSignalMock &instance()
+    {
+        static FirstFrameReceivedSignalMock instance;
+        return instance;
+    }
+    MOCK_METHOD(void, callbackCalled, (), (const));
+};
+void firstFrameReceivedSignalCallback(GstElement *, gpointer, guint, gpointer)
+{
+    FirstFrameReceivedSignalMock::instance().callbackCalled();
+}
 } // namespace
 
 class GstreamerMseMediaPlayerClientTests : public RialtoGstTest
@@ -626,6 +640,31 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToNotifyBufferUnderflowWhen
     expectCallInEventLoop();
     expectPostMessage();
     m_sut->notifyBufferUnderflow(kUnknownSourceId);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotifyFirstFrameReceived)
+{
+    RialtoMSEBaseSink *videoSink = createVideoSink();
+
+    g_signal_connect(videoSink, "first-video-frame-callback", G_CALLBACK(firstFrameReceivedSignalCallback), nullptr);
+
+    bufferPullerWillBeCreated();
+    const int32_t kSourceId{attachSource(videoSink, firebolt::rialto::MediaSourceType::VIDEO)};
+
+    expectPostMessage();
+    // No mutex/cv needed, signal emission is synchronous
+    EXPECT_CALL(FirstFrameReceivedSignalMock::instance(), callbackCalled());
+    m_sut->notifyFirstFrameReceived(kSourceId);
+
+    gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
+    gst_object_unref(videoSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToNotifyFirstFrameReceivedWhenSourceIdIsNotKnown)
+{
+    expectCallInEventLoop();
+    expectPostMessage();
+    m_sut->notifyFirstFrameReceived(kUnknownSourceId);
 }
 
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotifyDecryptionPlaybackError)


### PR DESCRIPTION
Summary: Add first-video-frame-callback signal implementation.
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-13397