### PR TITLE
get volume directly when fade volume is enabled

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -774,6 +774,13 @@ void GStreamerMSEMediaPlayerClient::setVolume(double targetVolume, uint32_t volu
 
 bool GStreamerMSEMediaPlayerClient::getVolume(double &volume)
 {
+    bool success{false};
+    m_backendQueue->callInEventLoop([&]() { success = m_clientBackend->getVolume(volume); });
+    return success;
+}
+
+bool GStreamerMSEMediaPlayerClient::getCachedVolume(double &volume)
+{
     std::unique_lock lock{m_playbackInfoMutex};
     volume = m_playbackInfo.volume;
     return true;

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -307,6 +307,7 @@ public:
     bool renderFrame(int32_t sourceId);
     void setVolume(double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType easeType);
     bool getVolume(double &volume);
+    bool getCachedVolume(double &volume);
     void setMute(bool mute, int32_t sourceId);
     bool getMute(int sourceId);
     void setTextTrackIdentifier(const std::string &textTrackIdentifier);

--- a/source/PullModeAudioPlaybackDelegate.cpp
+++ b/source/PullModeAudioPlaybackDelegate.cpp
@@ -223,7 +223,7 @@ void PullModeAudioPlaybackDelegate::getProperty(const Property &type, GValue *va
         double volume{1.0};
         if (client)
         {
-            if (client->getVolume(volume))
+            if (client->getCachedVolume(volume))
                 m_targetVolume = volume;
             else
                 volume = m_targetVolume; // Use last known volume

--- a/tests/ut/GstreamerMseAudioSinkTests.cpp
+++ b/tests/ut/GstreamerMseAudioSinkTests.cpp
@@ -547,10 +547,10 @@ TEST_F(GstreamerMseAudioSinkTests, ShouldGetFadeVolumeProperty)
 {
     TestContext textContext = createPipelineWithAudioSinkAndSetToPaused();
 
-    constexpr int64_t kPosition{1234};
     guint fadeVolume{0};
     constexpr guint kFadeVolume{5};
-    sendPlaybackInfoNotification(textContext.m_sink, firebolt::rialto::PlaybackInfo{kPosition, kFadeVolume / 100.0});
+    EXPECT_CALL(m_mediaPipelineMock, getVolume(_))
+        .WillOnce(DoAll(SetArgReferee<0>(static_cast<double>(kFadeVolume) / 100.0), Return(true)));
     g_object_get(textContext.m_sink, "fade-volume", &fadeVolume, nullptr);
     EXPECT_EQ(fadeVolume, kFadeVolume);
 

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -1255,13 +1255,31 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSetVolume)
     m_sut->setVolume(kVolume, kVolumeDuration, kEaseType);
 }
 
-TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetVolume)
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetCachedVolume)
 {
     double volume{0.0};
     RialtoMSEBaseSink *audioSink = createAudioSink();
     bufferPullerWillBeCreated();
     attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
     m_sut->notifyPlaybackInfo(firebolt::rialto::PlaybackInfo{kPosition, kVolume});
+
+    EXPECT_TRUE(m_sut->getCachedVolume(volume));
+    EXPECT_EQ(volume, kVolume);
+
+    m_sut->destroyClientBackend();
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetVolume)
+{
+    double volume{0.0};
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, getVolume(_)).WillOnce(DoAll(SetArgReferee<0>(kVolume), Return(true)));
 
     EXPECT_TRUE(m_sut->getVolume(volume));
     EXPECT_EQ(volume, kVolume);


### PR DESCRIPTION
Summary: get volume directly when fade volume is enabled
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-18645