### PR TITLE
Change the decrypt method and add the OUTPUT_PROTECTION support in Rialto

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -41,6 +41,8 @@ const char *toString(const firebolt::rialto::PlaybackError &error)
     {
     case firebolt::rialto::PlaybackError::DECRYPTION:
         return "DECRYPTION";
+    case firebolt::rialto::PlaybackError::OUTPUT_PROTECTION:
+        return "OUTPUT_PROTECTION";
     case firebolt::rialto::PlaybackError::UNKNOWN:
         return "UNKNOWN";
     }
@@ -1072,20 +1074,38 @@ bool GStreamerMSEMediaPlayerClient::handlePlaybackError(int sourceId, firebolt::
                 return;
             }
 
-            // Even though rialto has only reported a non-fatal error, still fail the pipeline from rialto-gstreamer
-            GST_ERROR("Received Playback error '%s', posting error on %s sink", toString(error),
-                      toString(sourceIt->second.getType()));
-            if (firebolt::rialto::PlaybackError::DECRYPTION == error)
+            // OUTPUT_PROTECTION is handled separately by posting an application message (not a pipeline error)
+            if (firebolt::rialto::PlaybackError::OUTPUT_PROTECTION == error)
             {
-                sourceIt->second.m_delegate->handleError("Rialto dropped a frame that failed to decrypt",
-                                                         GST_STREAM_ERROR_DECRYPT);
+                GST_WARNING("HDCP output protection failure, posting HDCPProtectionFailure application message");
+                GstStructure *hdcpMsg = gst_structure_new("HDCPProtectionFailure", "message", G_TYPE_STRING,
+                                                          "HDCP Output Protection Error", "error", G_TYPE_STRING,
+                                                          toString(error), nullptr);
+                GstMessage *message =
+                    gst_message_new_application(GST_OBJECT_CAST(sourceIt->second.m_rialtoSink), hdcpMsg);
+                result = gst_element_post_message(GST_ELEMENT_CAST(sourceIt->second.m_rialtoSink), message);
+                if (!result)
+                {
+                    GST_WARNING("Failed to post HDCPProtectionFailure application message");
+                }
             }
             else
             {
-                sourceIt->second.m_delegate->handleError("Rialto server playback failed");
-            }
+                // For other playback errors, fail the pipeline from rialto-gstreamer
+                GST_ERROR("Received Playback error '%s', posting error on %s sink", toString(error),
+                          toString(sourceIt->second.getType()));
+                if (firebolt::rialto::PlaybackError::DECRYPTION == error)
+                {
+                    sourceIt->second.m_delegate->handleError("Rialto dropped a frame that failed to decrypt",
+                                                             GST_STREAM_ERROR_DECRYPT);
+                }
+                else
+                {
+                    sourceIt->second.m_delegate->handleError("Rialto server playback failed");
+                }
 
-            result = true;
+                result = true;
+            }
         });
 
     return result;

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -660,11 +660,51 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotifyUnknownPlaybackError)
     gst_object_unref(audioSink);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldPostHdcpProtectionFailureApplicationMessage)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+    rialto_mse_base_sink_initialise_delegate(audioSink, m_delegateMock);
+
+    EXPECT_CALL(*m_delegateMock, changeState(_)).Times(testing::AnyNumber()).WillRepeatedly(Return(GST_STATE_CHANGE_SUCCESS));
+    bufferPullerWillBeCreated();
+    const int32_t kSourceId{attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO)};
+
+    expectPostMessage();
+    m_sut->notifyPlaybackError(kSourceId, firebolt::rialto::PlaybackError::OUTPUT_PROTECTION);
+
+    GstMessage *receivedMessage{getMessage(pipeline, GST_MESSAGE_APPLICATION)};
+    ASSERT_NE(receivedMessage, nullptr);
+
+    const GstStructure *messageStructure = gst_message_get_structure(receivedMessage);
+    ASSERT_NE(messageStructure, nullptr);
+    EXPECT_STREQ(gst_structure_get_name(messageStructure), "HDCPProtectionFailure");
+
+    const gchar *message = gst_structure_get_string(messageStructure, "message");
+    ASSERT_NE(message, nullptr);
+    EXPECT_STREQ(message, "HDCP Output Protection Error");
+
+    const gchar *error = gst_structure_get_string(messageStructure, "error");
+    ASSERT_NE(error, nullptr);
+    EXPECT_STREQ(error, "OUTPUT_PROTECTION");
+
+    gst_message_unref(receivedMessage);
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(pipeline);
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToNotifyPlaybackErrorWhenSourceIdIsNotKnown)
 {
     expectCallInEventLoop();
     expectPostMessage();
     m_sut->notifyPlaybackError(kUnknownSourceId, firebolt::rialto::PlaybackError::DECRYPTION);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToNotifyOutputProtectionPlaybackErrorWhenSourceIdIsNotKnown)
+{
+    expectCallInEventLoop();
+    expectPostMessage();
+    m_sut->notifyPlaybackError(kUnknownSourceId, firebolt::rialto::PlaybackError::OUTPUT_PROTECTION);
 }
 
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldGetPosition)


### PR DESCRIPTION
Summary: Change the decrypt method and add the OUTPUT_PROTECTION support in Rialto
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: DELIA-70176