### PR TITLE
RDKEMW-15323 - Implement seek-state tracking in GST_QUERY_SEEKING for pull-mode 

### DIFF
--- a/source/PullModePlaybackDelegate.cpp
+++ b/source/PullModePlaybackDelegate.cpp
@@ -145,6 +145,13 @@ void PullModePlaybackDelegate::handleFlushCompleted()
     std::unique_lock<std::mutex> lock(m_sinkMutex);
     m_isServerFlushOngoing = false;
     m_isTimeResetOngoing = false;
+    if (!m_isSinkFlushOngoing)
+    {
+        if (m_isSeekOngoing.exchange(false))
+        {
+            GST_INFO_OBJECT(m_sink, "Seek finished (both sink and server flushes completed)");
+        }
+    }
 }
 
 void PullModePlaybackDelegate::handleStateChanged(firebolt::rialto::PlaybackState state)
@@ -454,7 +461,22 @@ std::optional<gboolean> PullModePlaybackDelegate::handleQuery(GstQuery *query) c
     {
         GstFormat fmt;
         gst_query_parse_seeking(query, &fmt, NULL, NULL, NULL);
-        gst_query_set_seeking(query, fmt, FALSE, 0, -1);
+        if (fmt == GST_FORMAT_TIME)
+        {
+            gboolean seekable = m_isSeekOngoing.load() ? FALSE : TRUE;
+            std::shared_ptr<GStreamerMSEMediaPlayerClient> client = m_mediaPlayerManager.getMediaPlayerClient();
+            int64_t duration{-1};
+            if (client)
+            {
+                client->getDuration(duration);
+            }
+            GST_DEBUG_OBJECT(m_sink, "Seeking query: seekable=%s", seekable ? "TRUE" : "FALSE");
+            gst_query_set_seeking(query, fmt, seekable, 0, duration > 0 ? duration : -1);
+        }
+        else
+        {
+            gst_query_set_seeking(query, fmt, FALSE, 0, -1);
+        }
         return TRUE;
     }
     case GST_QUERY_POSITION:
@@ -558,6 +580,8 @@ gboolean PullModePlaybackDelegate::handleSendEvent(GstEvent *event)
                 gst_event_unref(event);
                 return FALSE;
             }
+            m_isSeekOngoing = true;
+            GST_INFO_OBJECT(m_sink, "Seek started to position %" GST_TIME_FORMAT, GST_TIME_ARGS(start));
             // Update last segment
             if (seekFormat == GST_FORMAT_TIME)
             {
@@ -845,6 +869,7 @@ void PullModePlaybackDelegate::flushServer(bool resetTime)
     if (!client)
     {
         GST_ERROR_OBJECT(m_sink, "Could not get the media player client");
+        m_isSeekOngoing = false;
         return;
     }
 

--- a/source/PullModePlaybackDelegate.h
+++ b/source/PullModePlaybackDelegate.h
@@ -113,4 +113,5 @@ protected:
     firebolt::rialto::MediaSourceType m_mediaSourceType{firebolt::rialto::MediaSourceType::UNKNOWN};
     guint32 m_lastInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
     std::atomic<guint32> m_currentInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
+    std::atomic<bool> m_isSeekOngoing{false};
 };

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -2063,3 +2063,209 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldQueryDuration)
     gst_caps_unref(caps);
     gst_object_unref(pipeline);
 }
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnSeekableInTimeFormat)
+{
+    // When no seek is ongoing and no client is available, GST_QUERY_SEEKING in
+    // TIME format should return seekable=TRUE with duration=-1 (no client to query)
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_TIME)};
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(audioSink), query));
+
+    GstFormat fmt;
+    gboolean seekable{FALSE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_TIME);
+    EXPECT_TRUE(seekable);
+    EXPECT_EQ(segStart, 0);
+    EXPECT_EQ(segEnd, -1);
+
+    gst_query_unref(query);
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnNotSeekableInNonTimeFormat)
+{
+    // GST_QUERY_SEEKING in non-TIME format should always return seekable=FALSE
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_BYTES)};
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(audioSink), query));
+
+    GstFormat fmt;
+    gboolean seekable{TRUE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_BYTES);
+    EXPECT_FALSE(seekable);
+    EXPECT_EQ(segStart, 0);
+    EXPECT_EQ(segEnd, -1);
+
+    gst_query_unref(query);
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnSeekableWithDurationFromServer)
+{
+    // When a client is available, GST_QUERY_SEEKING should include duration from server
+    constexpr gint64 kDuration{5000000000};  // 5 seconds in nanoseconds
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_TIME)};
+    EXPECT_CALL(m_mediaPipelineMock, getDuration(_)).WillOnce(DoAll(SetArgReferee<0>(kDuration), Return(true)));
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(audioSink), query));
+
+    GstFormat fmt;
+    gboolean seekable{FALSE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_TIME);
+    EXPECT_TRUE(seekable);
+    EXPECT_EQ(segStart, 0);
+    EXPECT_EQ(segEnd, kDuration);
+
+    gst_query_unref(query);
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnSeekableWithNegativeDurationFromServer)
+{
+    // When server returns duration <= 0, seekable should still be TRUE but end = -1
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_TIME)};
+    EXPECT_CALL(m_mediaPipelineMock, getDuration(_)).WillOnce(DoAll(SetArgReferee<0>(-1), Return(true)));
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(audioSink), query));
+
+    GstFormat fmt;
+    gboolean seekable{FALSE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_TIME);
+    EXPECT_TRUE(seekable);
+    EXPECT_EQ(segStart, 0);
+    EXPECT_EQ(segEnd, -1);
+
+    gst_query_unref(query);
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnNotSeekableDuringOngoingSeek)
+{
+    // After a seek event is sent (even if upstream forward fails),
+    // m_isSeekOngoing is set to TRUE. GST_QUERY_SEEKING should return seekable=FALSE.
+    TestContext testContext = createPipelineWithAudioSinkAndSetToPaused();
+
+    sendPlaybackStateNotification(testContext.m_sink, firebolt::rialto::PlaybackState::PAUSED);
+    EXPECT_TRUE(waitForMessage(testContext.m_pipeline, GST_MESSAGE_ASYNC_DONE));
+
+    // Send a flush-seek event. It will return FALSE (no upstream) but m_isSeekOngoing is set.
+    EXPECT_FALSE(gst_element_seek(GST_ELEMENT_CAST(testContext.m_sink), 1.0, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH,
+                                  GST_SEEK_TYPE_SET, kStart, GST_SEEK_TYPE_NONE, kStop));
+
+    // During seek, query should return NOT seekable
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_TIME)};
+    EXPECT_CALL(m_mediaPipelineMock, getDuration(_)).WillOnce(DoAll(SetArgReferee<0>(5000000000), Return(true)));
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(testContext.m_sink), query));
+
+    GstFormat fmt;
+    gboolean seekable{TRUE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_TIME);
+    EXPECT_FALSE(seekable);
+    gst_query_unref(query);
+
+    setNullState(testContext.m_pipeline, testContext.m_sourceId);
+    gst_object_unref(testContext.m_pipeline);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldReturnSeekableAfterFlushCompletes)
+{
+    // After a seek is started and flush completes, m_isSeekOngoing should be cleared
+    // and GST_QUERY_SEEKING should return seekable=TRUE again.
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    // Set flushing
+    EXPECT_TRUE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                           gst_event_new_flush_start()));
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    sendPlaybackStateNotification(audioSink, firebolt::rialto::PlaybackState::PAUSED);
+    EXPECT_TRUE(waitForMessage(pipeline, GST_MESSAGE_ASYNC_DONE));
+
+    // Send seek event (returns FALSE because upstream push fails, but sets m_isSeekOngoing)
+    EXPECT_FALSE(gst_element_seek(GST_ELEMENT_CAST(audioSink), 1.0, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH,
+                                  GST_SEEK_TYPE_SET, kStart, GST_SEEK_TYPE_NONE, kStop));
+
+    EXPECT_CALL(m_mediaPipelineMock, flush(kSourceId, kResetTime, _)).WillOnce(Return(true));
+
+    std::mutex flushMutex;
+    std::condition_variable flushCond;
+    bool flushFlag{false};
+    std::thread t{[&]()
+                  {
+                      std::unique_lock<std::mutex> lock{flushMutex};
+                      flushCond.wait_for(lock, std::chrono::milliseconds{500}, [&]() { return flushFlag; });
+                      auto mediaPipelineClient = m_mediaPipelineClient.lock();
+                      ASSERT_TRUE(mediaPipelineClient);
+                      mediaPipelineClient->notifySourceFlushed(kSourceId);
+                      mediaPipelineClient.reset();
+                  }};
+
+    // flush_stop triggers flushServer which completes the flush cycle
+    EXPECT_TRUE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                           gst_event_new_flush_stop(kResetTime)));
+
+    // Signal server flush complete
+    {
+        std::unique_lock<std::mutex> lock{flushMutex};
+        flushFlag = true;
+        flushCond.notify_one();
+    }
+    t.join();
+
+    // After flush completed, query should return seekable=TRUE
+    GstQuery *query{gst_query_new_seeking(GST_FORMAT_TIME)};
+    EXPECT_CALL(m_mediaPipelineMock, getDuration(_)).WillOnce(DoAll(SetArgReferee<0>(5000000000), Return(true)));
+    EXPECT_TRUE(gst_element_query(GST_ELEMENT_CAST(audioSink), query));
+
+    GstFormat fmt;
+    gboolean seekable{FALSE};
+    gint64 segStart{0}, segEnd{0};
+    gst_query_parse_seeking(query, &fmt, &seekable, &segStart, &segEnd);
+    EXPECT_EQ(fmt, GST_FORMAT_TIME);
+    EXPECT_TRUE(seekable);
+    gst_query_unref(query);
+
+    setNullState(pipeline, kSourceId);
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}


### PR DESCRIPTION
Changes Made: Implement GST_QUERY_SEEKING with seek-state tracking in pull-mode delegate

- Return seekable=TRUE for TIME format when no seek is in progress, querying duration from Rialto server via getDuration()
- Add m_isSeekOngoing flag, set on flush-seek start in GST_EVENT_SEEK
- Detect seek completion when both m_isSinkFlushOngoing and m_isServerFlushOngoing are false (checked in handleFlushCompleted and stopFlushing)
- Block further seeks (seekable=FALSE) while flush cycle is active
- Handle edge cases: reset flag if flushServer fails (no client)
- 6 UT Created for the changes made

Summary: [RIALTO] Spotify unable to seek podcast assets - m0.4(UT Created)
Type: Fix
Test Plan: UT
Jira: RDKEMW-15323
Attaching the report : [coverage_report_m0.4.zip](https://github.com/user-attachments/files/29079126/coverage_report_m0.4.zip)
