### PR TITLE
RDKEMW-15125: [WPEWebKit] playback rate after seeking/rebuffering

### DIFF
--- a/source/PullModePlaybackDelegate.cpp
+++ b/source/PullModePlaybackDelegate.cpp
@@ -603,6 +603,7 @@ gboolean PullModePlaybackDelegate::handleSendEvent(GstEvent *event)
             GST_DEBUG_OBJECT(m_sink, "Instant playback rate change: %.2f", rate);
             m_currentInstantRateChangeSeqnum = seqnum;
             client->setPlaybackRate(rate);
+            m_lastPlaybackRate = rate;
         }
         break;
     }
@@ -785,6 +786,15 @@ void PullModePlaybackDelegate::setSegment()
     const bool kResetTime{m_lastSegment.flags == GST_SEGMENT_FLAG_RESET};
     int64_t position = static_cast<int64_t>(m_lastSegment.start);
     client->setSourcePosition(m_sourceId, position, kResetTime, m_lastSegment.applied_rate, m_lastSegment.stop);
+
+    // Send Playback Rate if it differs from the last rate we applied.
+    if (m_lastSegment.rate != m_lastPlaybackRate && m_mediaPlayerManager.hasControl())
+    {
+        GST_DEBUG_OBJECT(m_sink, "Setting playback rate to %.2f", m_lastSegment.rate);
+        client->setPlaybackRate(m_lastSegment.rate);
+        m_lastPlaybackRate = m_lastSegment.rate;
+    }
+
     m_segmentSet = true;
 }
 
@@ -799,6 +809,7 @@ void PullModePlaybackDelegate::changePlaybackRate(GstEvent *event)
         {
             GST_DEBUG_OBJECT(m_sink, "Instant playback rate change: %.2f", playbackRate);
             client->setPlaybackRate(playbackRate);
+            m_lastPlaybackRate = playbackRate;
         }
     }
 }

--- a/source/PullModePlaybackDelegate.h
+++ b/source/PullModePlaybackDelegate.h
@@ -113,4 +113,5 @@ protected:
     firebolt::rialto::MediaSourceType m_mediaSourceType{firebolt::rialto::MediaSourceType::UNKNOWN};
     guint32 m_lastInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
     std::atomic<guint32> m_currentInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
+    gdouble m_lastPlaybackRate{1.0};
 };

--- a/source/PullModePlaybackDelegate.h
+++ b/source/PullModePlaybackDelegate.h
@@ -113,5 +113,5 @@ protected:
     firebolt::rialto::MediaSourceType m_mediaSourceType{firebolt::rialto::MediaSourceType::UNKNOWN};
     guint32 m_lastInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
     std::atomic<guint32> m_currentInstantRateChangeSeqnum{GST_SEQNUM_INVALID};
-    gdouble m_lastPlaybackRate{1.0};
+    std::atomic<gdouble> m_lastPlaybackRate{1.0};
 };

--- a/tests/ut/GstreamerMseBaseSinkTests.cpp
+++ b/tests/ut/GstreamerMseBaseSinkTests.cpp
@@ -1066,6 +1066,90 @@ TEST_F(GstreamerMseBaseSinkTests, ShouldSetSourcePositionWithNonDefaultAppliedRa
     gst_object_unref(pipeline);
 }
 
+TEST_F(GstreamerMseBaseSinkTests, ShouldSetPlaybackRateWhenSegmentRateDiffersFromLastApplied)
+{
+    constexpr guint64 kPosition{1234};
+    constexpr bool kResetTime{false};
+    constexpr double kAppliedRate{1.0};
+    constexpr double kSegmentRate{2.0};
+    constexpr uint64_t kStopPosition{GST_CLOCK_TIME_NONE};
+
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    sendPlaybackStateNotification(audioSink, firebolt::rialto::PlaybackState::PAUSED);
+    EXPECT_TRUE(waitForMessage(pipeline, GST_MESSAGE_ASYNC_DONE));
+
+    EXPECT_CALL(m_mediaPipelineMock, setSourcePosition(kSourceId, kPosition, kResetTime, kAppliedRate, kStopPosition))
+        .WillOnce(Return(true));
+    EXPECT_CALL(m_mediaPipelineMock, setPlaybackRate(kSegmentRate)).WillOnce(Return(true));
+
+    GstSegment *segment{gst_segment_new()};
+    gst_segment_init(segment, GST_FORMAT_TIME);
+    gst_segment_do_seek(segment, kSegmentRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
+                        GST_SEEK_TYPE_SET, kStopPosition, nullptr);
+
+    EXPECT_TRUE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                           gst_event_new_segment(segment)));
+
+    gst_segment_free(segment);
+
+    setNullState(pipeline, kSourceId);
+
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
+TEST_F(GstreamerMseBaseSinkTests, ShouldNotSetPlaybackRateWhenSegmentRateMatchesLastApplied)
+{
+    constexpr guint64 kPosition{1234};
+    constexpr bool kResetTime{false};
+    constexpr double kAppliedRate{1.0};
+    constexpr double kSegmentRate{1.0}; // matches default m_lastPlaybackRate
+    constexpr uint64_t kStopPosition{GST_CLOCK_TIME_NONE};
+
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    GstElement *pipeline = createPipelineWithSink(audioSink);
+
+    setPausedState(pipeline, audioSink);
+    const int32_t kSourceId{audioSourceWillBeAttached(createAudioMediaSource())};
+    allSourcesWillBeAttached();
+
+    GstCaps *caps{createAudioCaps()};
+    setCaps(audioSink, caps);
+
+    sendPlaybackStateNotification(audioSink, firebolt::rialto::PlaybackState::PAUSED);
+    EXPECT_TRUE(waitForMessage(pipeline, GST_MESSAGE_ASYNC_DONE));
+
+    // setSourcePosition is expected, but setPlaybackRate must NOT be called because the
+    // segment rate equals the last applied playback rate. StrictMock will fail the test
+    // if setPlaybackRate is invoked.
+    EXPECT_CALL(m_mediaPipelineMock, setSourcePosition(kSourceId, kPosition, kResetTime, kAppliedRate, kStopPosition))
+        .WillOnce(Return(true));
+
+    GstSegment *segment{gst_segment_new()};
+    gst_segment_init(segment, GST_FORMAT_TIME);
+    gst_segment_do_seek(segment, kSegmentRate, GST_FORMAT_TIME, GST_SEEK_FLAG_NONE, GST_SEEK_TYPE_SET, kPosition,
+                        GST_SEEK_TYPE_SET, kStopPosition, nullptr);
+
+    EXPECT_TRUE(rialto_mse_base_sink_event(audioSink->priv->m_sinkPad, GST_OBJECT_CAST(audioSink),
+                                           gst_event_new_segment(segment)));
+
+    gst_segment_free(segment);
+
+    setNullState(pipeline, kSourceId);
+
+    gst_caps_unref(caps);
+    gst_object_unref(pipeline);
+}
+
 TEST_F(GstreamerMseBaseSinkTests, ShouldHandleEos)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();


### PR DESCRIPTION
RDKEMW-15125: [WPEWebKit] playback rate after seeking/rebuffering
Summary: Playback rate is not set properly when the seek path is chosen instead of instant rate change path.
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-15125