### PR TITLE
Add support for 'first-audio-frame-callback' signal

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -1083,6 +1083,11 @@ bool GStreamerMSEMediaPlayerClient::handleFirstFrameReceived(int sourceId)
                 rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(sourceIt->second.m_rialtoSink);
                 result = true;
             }
+            else if (sourceIt->second.getType() == firebolt::rialto::MediaSourceType::AUDIO)
+            {
+                rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(sourceIt->second.m_rialtoSink);
+                result = true;
+            }
         });
 
     return result;

--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -19,6 +19,7 @@
 #include "GStreamerMSEMediaPlayerClient.h"
 #include "Constants.h"
 #include "GstreamerCatLog.h"
+#include "RialtoGStreamerMSEAudioSink.h"
 #include "RialtoGStreamerMSEBaseSink.h"
 #include "RialtoGStreamerMSEBaseSinkPrivate.h"
 #include "RialtoGStreamerMSEVideoSink.h"
@@ -1080,12 +1081,14 @@ bool GStreamerMSEMediaPlayerClient::handleFirstFrameReceived(int sourceId)
             }
             if (sourceIt->second.getType() == firebolt::rialto::MediaSourceType::VIDEO)
             {
-                rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(sourceIt->second.m_rialtoSink);
+                rialto_mse_video_handle_rialto_server_sent_first_video_frame_received(
+                    RIALTO_MSE_VIDEO_SINK(sourceIt->second.m_rialtoSink));
                 result = true;
             }
             else if (sourceIt->second.getType() == firebolt::rialto::MediaSourceType::AUDIO)
             {
-                rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(sourceIt->second.m_rialtoSink);
+                rialto_mse_audio_handle_rialto_server_sent_first_audio_frame_received(
+                    RIALTO_MSE_AUDIO_SINK(sourceIt->second.m_rialtoSink));
                 result = true;
             }
         });

--- a/source/RialtoGStreamerMSEAudioSink.cpp
+++ b/source/RialtoGStreamerMSEAudioSink.cpp
@@ -57,6 +57,20 @@ enum
     PROP_LAST
 };
 
+enum
+{
+    SIGNAL_FIRST_AUDIO_FRAME_RECEIVED,
+    SIGNAL_LAST
+};
+
+static guint g_signals[SIGNAL_LAST] = {0};
+
+void rialto_mse_audio_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEAudioSink *sink)
+{
+    GST_INFO_OBJECT(sink, "Sending first audio frame received signal");
+    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED], 0, 0, nullptr);
+}
+
 static GstStateChangeReturn rialto_mse_audio_sink_change_state(GstElement *element, GstStateChange transition)
 {
     RialtoMSEBaseSink *sink = RIALTO_MSE_BASE_SINK(element);
@@ -282,6 +296,11 @@ static void rialto_mse_audio_sink_class_init(RialtoMSEAudioSinkClass *klass)
                                     g_param_spec_boolean("web-audio",
                                                          "Webaudio mode", "Enable webaudio mode. Property should be set before NULL->READY transition",
                                                          FALSE, G_PARAM_READWRITE));
+
+    g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED] = g_signal_new("first-audio-frame-callback", G_TYPE_FROM_CLASS(klass),
+                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
+                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
+                                                                G_TYPE_UINT, G_TYPE_POINTER);
 
     std::unique_ptr<firebolt::rialto::IMediaPipelineCapabilities> mediaPlayerCapabilities =
         firebolt::rialto::IMediaPipelineCapabilitiesFactory::createFactory()->createMediaPipelineCapabilities();

--- a/source/RialtoGStreamerMSEAudioSink.h
+++ b/source/RialtoGStreamerMSEAudioSink.h
@@ -46,6 +46,7 @@ struct _RialtoMSEAudioSinkClass
 };
 
 GType rialto_mse_audio_sink_get_type(void);
+void rialto_mse_audio_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEAudioSink *sink);
 
 void rialto_mse_audio_sink_set_client_backend(GstElement *sink,
                                               const std::shared_ptr<GStreamerMSEMediaPlayerClient> &mediaPlayerClient);

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -56,6 +56,7 @@ enum
 {
     SIGNAL_UNDERFLOW,
     SIGNAL_FIRST_VIDEO_FRAME_RECEIVED,
+    SIGNAL_FIRST_AUDIO_FRAME_RECEIVED,
     SIGNAL_LAST
 };
 
@@ -273,6 +274,12 @@ void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(Rialto
     g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED], 0, 0, nullptr);
 }
 
+void rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEBaseSink *sink)
+{
+    GST_INFO_OBJECT(sink, "Sending first audio frame received signal");
+    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED], 0, 0, nullptr);
+}
+
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink)
 {
     GstPadTemplate *pad_template =
@@ -342,6 +349,10 @@ static void rialto_mse_base_sink_class_init(RialtoMSEBaseSinkClass *klass)
                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2, G_TYPE_UINT,
                                                G_TYPE_POINTER);
     g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
+                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
+                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
+                                                                G_TYPE_UINT, G_TYPE_POINTER);
+    g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED] = g_signal_new("first-audio-frame-callback", G_TYPE_FROM_CLASS(klass),
                                                                 (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
                                                                 g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
                                                                 G_TYPE_UINT, G_TYPE_POINTER);

--- a/source/RialtoGStreamerMSEBaseSink.cpp
+++ b/source/RialtoGStreamerMSEBaseSink.cpp
@@ -55,8 +55,6 @@ enum
 enum
 {
     SIGNAL_UNDERFLOW,
-    SIGNAL_FIRST_VIDEO_FRAME_RECEIVED,
-    SIGNAL_FIRST_AUDIO_FRAME_RECEIVED,
     SIGNAL_LAST
 };
 
@@ -268,18 +266,6 @@ void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSin
     g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_UNDERFLOW], 0, 0, nullptr);
 }
 
-void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(RialtoMSEBaseSink *sink)
-{
-    GST_INFO_OBJECT(sink, "Sending first frame received signal");
-    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED], 0, 0, nullptr);
-}
-
-void rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEBaseSink *sink)
-{
-    GST_INFO_OBJECT(sink, "Sending first audio frame received signal");
-    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED], 0, 0, nullptr);
-}
-
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink)
 {
     GstPadTemplate *pad_template =
@@ -348,14 +334,7 @@ static void rialto_mse_base_sink_class_init(RialtoMSEBaseSinkClass *klass)
                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2, G_TYPE_UINT,
                                                G_TYPE_POINTER);
-    g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
-                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
-                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
-                                                                G_TYPE_UINT, G_TYPE_POINTER);
-    g_signals[SIGNAL_FIRST_AUDIO_FRAME_RECEIVED] = g_signal_new("first-audio-frame-callback", G_TYPE_FROM_CLASS(klass),
-                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
-                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
-                                                                G_TYPE_UINT, G_TYPE_POINTER);
+
     g_object_class_install_property(gobjectClass, PROP_IS_SINGLE_PATH_STREAM,
                                     g_param_spec_boolean("single-path-stream", "single path stream",
                                                          "is single path stream", FALSE, GParamFlags(G_PARAM_READWRITE)));

--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -70,5 +70,6 @@ bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
 void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(RialtoMSEBaseSink *sink);
+void rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEBaseSink *sink);
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEBaseSink.h
+++ b/source/RialtoGStreamerMSEBaseSink.h
@@ -69,7 +69,5 @@ gboolean rialto_mse_base_sink_event(GstPad *pad, GstObject *parent, GstEvent *ev
 bool rialto_mse_base_sink_initialise_sinkpad(RialtoMSEBaseSink *sink);
 
 void rialto_mse_base_handle_rialto_server_sent_buffer_underflow(RialtoMSEBaseSink *sink);
-void rialto_mse_base_handle_rialto_server_sent_first_video_frame_received(RialtoMSEBaseSink *sink);
-void rialto_mse_base_handle_rialto_server_sent_first_audio_frame_received(RialtoMSEBaseSink *sink);
 
 G_END_DECLS

--- a/source/RialtoGStreamerMSEVideoSink.cpp
+++ b/source/RialtoGStreamerMSEVideoSink.cpp
@@ -54,6 +54,20 @@ enum
     PROP_LAST
 };
 
+enum
+{
+    SIGNAL_FIRST_VIDEO_FRAME_RECEIVED,
+    SIGNAL_LAST
+};
+
+static guint g_signals[SIGNAL_LAST] = {0};
+
+void rialto_mse_video_handle_rialto_server_sent_first_video_frame_received(RialtoMSEVideoSink *sink)
+{
+    GST_INFO_OBJECT(sink, "Sending first frame received signal");
+    g_signal_emit(G_OBJECT(sink), g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED], 0, 0, nullptr);
+}
+
 static GstStateChangeReturn rialto_mse_video_sink_change_state(GstElement *element, GstStateChange transition)
 {
     RialtoMSEVideoSink *sink = RIALTO_MSE_VIDEO_SINK(element);
@@ -247,6 +261,11 @@ static void rialto_mse_video_sink_class_init(RialtoMSEVideoSinkClass *klass)
     g_object_class_install_property(gobjectClass, PROP_VIDEO_PTS,
                                     g_param_spec_int64("video_pts", "video PTS", "current video PTS value", G_MININT64,
                                                        G_MAXINT64, 0, G_PARAM_READABLE));
+
+    g_signals[SIGNAL_FIRST_VIDEO_FRAME_RECEIVED] = g_signal_new("first-video-frame-callback", G_TYPE_FROM_CLASS(klass),
+                                                                (GSignalFlags)(G_SIGNAL_RUN_LAST), 0, nullptr, nullptr,
+                                                                g_cclosure_marshal_VOID__UINT_POINTER, G_TYPE_NONE, 2,
+                                                                G_TYPE_UINT, G_TYPE_POINTER);
 
     std::unique_ptr<firebolt::rialto::IMediaPipelineCapabilities> mediaPlayerCapabilities =
         firebolt::rialto::IMediaPipelineCapabilitiesFactory::createFactory()->createMediaPipelineCapabilities();

--- a/source/RialtoGStreamerMSEVideoSink.h
+++ b/source/RialtoGStreamerMSEVideoSink.h
@@ -46,6 +46,7 @@ struct _RialtoMSEVideoSinkClass
 };
 
 GType rialto_mse_video_sink_get_type(void);
+void rialto_mse_video_handle_rialto_server_sent_first_video_frame_received(RialtoMSEVideoSink *sink);
 
 void rialto_mse_video_sink_set_client_backend(GstElement *sink,
                                               const std::shared_ptr<GStreamerMSEMediaPlayerClient> &mediaPlayerClient);

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -660,6 +660,24 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotifyFirstFrameReceived)
     gst_object_unref(videoSink);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotifyFirstAudioFrameReceived)
+{
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+
+    g_signal_connect(audioSink, "first-audio-frame-callback", G_CALLBACK(firstFrameReceivedSignalCallback), nullptr);
+
+    bufferPullerWillBeCreated();
+    const int32_t kSourceId{attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO)};
+
+    expectPostMessage();
+    // No mutex/cv needed, signal emission is synchronous
+    EXPECT_CALL(FirstFrameReceivedSignalMock::instance(), callbackCalled());
+    m_sut->notifyFirstFrameReceived(kSourceId);
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToNotifyFirstFrameReceivedWhenSourceIdIsNotKnown)
 {
     expectCallInEventLoop();


### PR DESCRIPTION
        Summary: Add support for 'first-audio-frame-callback' signal to Rialto sink
        Type: Fix
        Test Plan: UT/CT, Fullstack
        Jira: RDKEMW-17882