### PR TITLE
Prevent sending AllSourcesAttached at teardown already requested

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -546,8 +546,19 @@ void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossible()
     m_backendQueue->callInEventLoop([&]() { sendAllSourcesAttachedIfPossibleInternal(); });
 }
 
+void GStreamerMSEMediaPlayerClient::notifyStopping()
+{
+    m_backendQueue->callInEventLoop([&]() { m_isStopping = true; });
+}
+
 void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossibleInternal()
 {
+    if (m_isStopping)
+    {
+        GST_INFO("Skip sending allSourcesAttached, because a stop was already requested");
+        return;
+    }
+
     if (!m_wasAllSourcesAttachedSent && areAllStreamsAttached())
     {
         // RialtoServer doesn't support dynamic source attachment.

--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -546,9 +546,9 @@ void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossible()
     m_backendQueue->callInEventLoop([&]() { sendAllSourcesAttachedIfPossibleInternal(); });
 }
 
-void GStreamerMSEMediaPlayerClient::notifyStopping()
+void GStreamerMSEMediaPlayerClient::setStopping(bool stopping)
 {
-    m_backendQueue->callInEventLoop([&]() { m_isStopping = true; });
+    m_backendQueue->callInEventLoop([this, stopping]() { m_isStopping = stopping; });
 }
 
 void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossibleInternal()

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -293,7 +293,7 @@ public:
     void handlePlaybackStateChange(firebolt::rialto::PlaybackState state);
     void handleSourceFlushed(int32_t sourceId);
     void sendAllSourcesAttachedIfPossible();
-    void notifyStopping();
+    void setStopping(bool stopping);
 
     void setVideoRectangle(const std::string &rectangleString);
     std::string getVideoRectangle();

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -293,6 +293,7 @@ public:
     void handlePlaybackStateChange(firebolt::rialto::PlaybackState state);
     void handleSourceFlushed(int32_t sourceId);
     void sendAllSourcesAttachedIfPossible();
+    void notifyStopping();
 
     void setVideoRectangle(const std::string &rectangleString);
     std::string getVideoRectangle();
@@ -338,6 +339,7 @@ private:
     std::mutex m_playbackInfoMutex;
     std::unordered_map<int32_t, AttachedSource> m_attachedSources;
     bool m_wasAllSourcesAttachedSent = false;
+    bool m_isStopping = false;
     int32_t m_audioStreams;
     int32_t m_videoStreams;
     int32_t m_subtitleStreams;

--- a/source/PullModePlaybackDelegate.cpp
+++ b/source/PullModePlaybackDelegate.cpp
@@ -213,6 +213,8 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
             return GST_STATE_CHANGE_FAILURE;
         }
 
+        client->setStopping(false);
+
         m_isSinkFlushOngoing = false;
 
         StateChangeResult result = client->pause(m_sourceId);
@@ -277,7 +279,7 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
             return GST_STATE_CHANGE_FAILURE;
         }
 
-        client->notifyStopping();
+        client->setStopping(true);
 
         if (m_isStateCommitNeeded)
         {
@@ -295,10 +297,6 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
     case GST_STATE_CHANGE_READY_TO_NULL:
         // Playback will be stopped once all sources are finished and ref count
         // of the media pipeline object reaches 0
-        if (client)
-        {
-            client->notifyStopping();
-        }
         m_mediaPlayerManager.releaseMediaPlayerClient();
         m_rialtoControlClient->removeControlBackend();
         break;

--- a/source/PullModePlaybackDelegate.cpp
+++ b/source/PullModePlaybackDelegate.cpp
@@ -277,6 +277,8 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
             return GST_STATE_CHANGE_FAILURE;
         }
 
+        client->notifyStopping();
+
         if (m_isStateCommitNeeded)
         {
             GST_DEBUG_OBJECT(m_sink, "Sending async_done in PAUSED->READY transition");
@@ -293,6 +295,10 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
     case GST_STATE_CHANGE_READY_TO_NULL:
         // Playback will be stopped once all sources are finished and ref count
         // of the media pipeline object reaches 0
+        if (client)
+        {
+            client->notifyStopping();
+        }
         m_mediaPlayerManager.releaseMediaPlayerClient();
         m_rialtoControlClient->removeControlBackend();
         break;

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -860,6 +860,45 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotOverwriteStreamCollectionSet
     gst_object_unref(audioSink);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSendAllSourcesAttachedWhenStopping)
+{
+    expectCallInEventLoop();
+    m_sut->handleStreamCollection(1, 0, 0);
+
+    // Teardown (PAUSED->READY / READY->NULL) requested before the source finished attaching.
+    m_sut->setStopping(true);
+
+    // allSourcesAttached() must NOT be sent - the StrictMock backend would flag it as an unexpected call.
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    EXPECT_EQ(m_sut->getClientState(), ClientState::IDLE);
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSendAllSourcesAttachedAfterStoppingReset)
+{
+    expectCallInEventLoop();
+    m_sut->handleStreamCollection(1, 0, 0);
+
+    // Stopping is requested then cleared (e.g. a READY->PAUSED re-init), so all sources attached can be notified again.
+    m_sut->setStopping(true);
+    m_sut->setStopping(false);
+
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, allSourcesAttached()).WillOnce(Return(true));
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    EXPECT_EQ(m_sut->getClientState(), ClientState::READY);
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSendPlayWhenNotAllSourcesAttached)
 {
     constexpr int32_t kVideoStreams{1};


### PR DESCRIPTION
Summary: Prevent sending AllSourcesAttached at teardown already requested (#245).
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-21806