### PR TITLE
Prevent sending AllSourcesAttached at teardown already requested (#247)

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -546,8 +546,19 @@ void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossible()
     m_backendQueue->callInEventLoop([&]() { sendAllSourcesAttachedIfPossibleInternal(); });
 }
 
+void GStreamerMSEMediaPlayerClient::setStopping(bool stopping)
+{
+    m_backendQueue->callInEventLoop([this, stopping]() { m_isStopping = stopping; });
+}
+
 void GStreamerMSEMediaPlayerClient::sendAllSourcesAttachedIfPossibleInternal()
 {
+    if (m_isStopping)
+    {
+        GST_INFO("Skip sending allSourcesAttached, because a stop was already requested");
+        return;
+    }
+
     if (!m_wasAllSourcesAttachedSent && areAllStreamsAttached())
     {
         // RialtoServer doesn't support dynamic source attachment.

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -293,6 +293,7 @@ public:
     void handlePlaybackStateChange(firebolt::rialto::PlaybackState state);
     void handleSourceFlushed(int32_t sourceId);
     void sendAllSourcesAttachedIfPossible();
+    void setStopping(bool stopping);
 
     void setVideoRectangle(const std::string &rectangleString);
     std::string getVideoRectangle();
@@ -338,6 +339,7 @@ private:
     std::mutex m_playbackInfoMutex;
     std::unordered_map<int32_t, AttachedSource> m_attachedSources;
     bool m_wasAllSourcesAttachedSent = false;
+    bool m_isStopping = false;
     int32_t m_audioStreams;
     int32_t m_videoStreams;
     int32_t m_subtitleStreams;

--- a/source/PullModePlaybackDelegate.cpp
+++ b/source/PullModePlaybackDelegate.cpp
@@ -214,6 +214,8 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
             return GST_STATE_CHANGE_FAILURE;
         }
 
+        client->setStopping(false);
+
         m_isSinkFlushOngoing = false;
 
         StateChangeResult result = client->pause(m_sourceId);
@@ -277,6 +279,8 @@ GstStateChangeReturn PullModePlaybackDelegate::changeState(GstStateChange transi
             GST_ERROR_OBJECT(m_sink, "Cannot get the media player client object");
             return GST_STATE_CHANGE_FAILURE;
         }
+
+        client->setStopping(true);
 
         if (m_isStateCommitNeeded)
         {

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -900,6 +900,45 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotOverwriteStreamCollectionSet
     gst_object_unref(audioSink);
 }
 
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSendAllSourcesAttachedWhenStopping)
+{
+    expectCallInEventLoop();
+    m_sut->handleStreamCollection(1, 0, 0);
+
+    // Teardown (PAUSED->READY / READY->NULL) requested before the source finished attaching.
+    m_sut->setStopping(true);
+
+    // allSourcesAttached() must NOT be sent - the StrictMock backend would flag it as an unexpected call.
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    EXPECT_EQ(m_sut->getClientState(), ClientState::IDLE);
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
+TEST_F(GstreamerMseMediaPlayerClientTests, ShouldSendAllSourcesAttachedAfterStoppingReset)
+{
+    expectCallInEventLoop();
+    m_sut->handleStreamCollection(1, 0, 0);
+
+    // Stopping is requested then cleared (e.g. a READY->PAUSED re-init), so all sources attached can be notified again.
+    m_sut->setStopping(true);
+    m_sut->setStopping(false);
+
+    RialtoMSEBaseSink *audioSink = createAudioSink();
+    bufferPullerWillBeCreated();
+    EXPECT_CALL(*m_mediaPlayerClientBackendMock, allSourcesAttached()).WillOnce(Return(true));
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+
+    EXPECT_EQ(m_sut->getClientState(), ClientState::READY);
+
+    gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
+    gst_object_unref(audioSink);
+}
+
 TEST_F(GstreamerMseMediaPlayerClientTests, ShouldNotSendPlayWhenNotAllSourcesAttached)
 {
     constexpr int32_t kVideoStreams{1};


### PR DESCRIPTION
RDKEMW-22157: Bringing changes from Rialto-gstreamer release branch 20.1 to 17.0 

Summary: Bringing fixes from release/v0.20.1 to v0.17.0 branch
Type: Fix
Test Plan: UT/CT, Fullstack
Jira: RDKEMW-20535, RDKEMW-21216, RDKEMW-21806, RDKEMW -18434