### PR TITLE
RDKEMW-18557: NTS Failure with Rialto on Sky-XiOne-UK-BCM

### DIFF
--- a/source/GStreamerMSEMediaPlayerClient.cpp
+++ b/source/GStreamerMSEMediaPlayerClient.cpp
@@ -789,23 +789,10 @@ std::string GStreamerMSEMediaPlayerClient::getVideoRectangle()
     return std::string(rectangle);
 }
 
-bool GStreamerMSEMediaPlayerClient::renderFrame(int32_t sourceId)
+bool GStreamerMSEMediaPlayerClient::renderFrame()
 {
     bool result = false;
-    m_backendQueue->callInEventLoop(
-        [&]()
-        {
-            result = m_clientBackend->renderFrame();
-            if (result)
-            {
-                // RialtoServer's video sink should drop PAUSED state due to skipping prerolled buffer in PAUSED state
-                auto sourceIt = m_attachedSources.find(sourceId);
-                if (sourceIt != m_attachedSources.end())
-                {
-                    sourceIt->second.m_delegate->lostState();
-                }
-            }
-        });
+    m_backendQueue->callInEventLoop([&]() { result = m_clientBackend->renderFrame(); });
     return result;
 }
 

--- a/source/GStreamerMSEMediaPlayerClient.h
+++ b/source/GStreamerMSEMediaPlayerClient.h
@@ -320,7 +320,7 @@ public:
     bool handlePlaybackError(int sourceId, firebolt::rialto::PlaybackError error);
     void stopStreaming();
     void destroyClientBackend();
-    bool renderFrame(int32_t sourceId);
+    bool renderFrame();
     void setVolume(double targetVolume, uint32_t volumeDuration, firebolt::rialto::EaseType easeType);
     bool getVolume(double &volume);
     bool getCachedVolume(double &volume);

--- a/source/PullModeVideoPlaybackDelegate.cpp
+++ b/source/PullModeVideoPlaybackDelegate.cpp
@@ -321,7 +321,7 @@ void PullModeVideoPlaybackDelegate::setProperty(const Property &type, const GVal
         if (client && stepOnPrerollEnabled && !m_stepOnPrerollEnabled)
         {
             GST_INFO_OBJECT(m_sink, "Frame stepping on preroll");
-            client->renderFrame(m_sourceId);
+            client->renderFrame();
         }
         m_stepOnPrerollEnabled = stepOnPrerollEnabled;
         break;

--- a/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
+++ b/tests/ut/GstreamerMseMediaPlayerClientTests.cpp
@@ -1416,11 +1416,11 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldFailToRenderFrame)
 {
     RialtoMSEBaseSink *audioSink = createAudioSink();
     bufferPullerWillBeCreated();
-    const auto kSourceId = attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
+    attachSource(audioSink, firebolt::rialto::MediaSourceType::AUDIO);
 
     expectCallInEventLoop();
     EXPECT_CALL(*m_mediaPlayerClientBackendMock, renderFrame()).WillOnce(Return(false));
-    EXPECT_FALSE(m_sut->renderFrame(kSourceId));
+    EXPECT_FALSE(m_sut->renderFrame());
 
     gst_element_set_state(GST_ELEMENT_CAST(audioSink), GST_STATE_NULL);
     gst_object_unref(audioSink);
@@ -1443,10 +1443,9 @@ TEST_F(GstreamerMseMediaPlayerClientTests, ShouldRenderFrame)
     expectCallInEventLoop();
     EXPECT_CALL(*m_mediaPlayerClientBackendMock, pause()).WillOnce(Return(true));
     EXPECT_CALL(*m_delegateMock, postAsyncStart());
-    EXPECT_CALL(*m_delegateMock, lostState());
     m_sut->pause(kVideoSourceId);
     EXPECT_CALL(*m_mediaPlayerClientBackendMock, renderFrame()).WillOnce(Return(true));
-    EXPECT_TRUE(m_sut->renderFrame(kVideoSourceId));
+    EXPECT_TRUE(m_sut->renderFrame());
 
     gst_element_set_state(GST_ELEMENT_CAST(videoSink), GST_STATE_NULL);
     gst_object_unref(videoSink);


### PR DESCRIPTION
RDKEMW-18557: Fix the NTS failure with Rialto on Sky-XiOne-UK-BCM

Reason for change: Disable forcing "loststate" after render frame
Test Procedure: https://ccp.sys.comcast.net/browse/RDKEMW-18557